### PR TITLE
Fix: Preserve existing metadata when initializing BlockNumberData

### DIFF
--- a/__tests__/units/block-finder/block-finder.test.ts
+++ b/__tests__/units/block-finder/block-finder.test.ts
@@ -250,6 +250,43 @@ describe("BlockFinder - findBlocksForDateRange", () => {
     }, 20000);
   });
 
+  describe("Metadata handling", () => {
+    it("should preserve existing metadata when initializing result", async () => {
+      // Arrange: Create existing data with custom metadata
+      const existingData: BlockNumberData = {
+        metadata: {
+          chain_id: 999, // Different from the provider's chain ID
+        },
+        blocks: {
+          "2024-01-15": 40000000,
+        },
+      };
+      testContext.fileManager.writeBlockNumbers(existingData);
+
+      // Act: Call findBlocksForDateRange which internally uses initializeResult
+      const result = await blockFinder.findBlocksForDateRange(
+        new Date("2024-01-16"),
+        new Date("2024-01-16"),
+      );
+
+      // Assert: The metadata should be preserved
+      expect(result.metadata.chain_id).toBe(999);
+    });
+
+    it("should set chain ID from provider when no existing metadata", async () => {
+      // Arrange: No existing data (empty file)
+
+      // Act: Call findBlocksForDateRange which internally uses initializeResult
+      const result = await blockFinder.findBlocksForDateRange(
+        new Date("2024-01-16"),
+        new Date("2024-01-16"),
+      );
+
+      // Assert: The metadata should be set from provider
+      expect(result.metadata.chain_id).toBe(CHAIN_IDS.ARBITRUM_NOVA);
+    });
+  });
+
   describe("Error handling", () => {
     it("should throw error with context when RPC provider is not available", async () => {
       // Create provider with explicit network to prevent retry loop

--- a/src/block-finder.ts
+++ b/src/block-finder.ts
@@ -32,11 +32,19 @@ export class BlockFinder {
   }
 
   private async initializeResult(): Promise<BlockNumberData> {
-    const { blocks } = this.fileManager.readBlockNumbers();
+    const existingData = this.fileManager.readBlockNumbers();
     const network = await this.provider.getNetwork();
+
+    // Preserve existing metadata if it has data in blocks (indicating it's not just default)
+    // Otherwise use chain ID from provider
+    const metadata =
+      Object.keys(existingData.blocks).length > 0
+        ? existingData.metadata
+        : { chain_id: Number(network.chainId) };
+
     return {
-      metadata: { chain_id: Number(network.chainId) },
-      blocks: { ...blocks },
+      metadata,
+      blocks: { ...existingData.blocks },
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed `BlockFinder.initializeResult()` to preserve existing metadata instead of always overwriting it with the chain ID from the provider
- Added tests to verify metadata preservation behavior

## Test plan
- [x] Added unit tests to verify metadata is preserved when existing data has blocks
- [x] Added unit tests to verify chain ID is set from provider when no existing data
- [x] All existing tests continue to pass
- [x] TypeScript and ESLint checks pass

Fixes #55