### PR TITLE
Refactor: Make FileManager accept store directory as constructor parameter

### DIFF
--- a/__tests__/units/file-manager/constructor-parameter.test.ts
+++ b/__tests__/units/file-manager/constructor-parameter.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "@jest/globals";
+import { FileManager } from "../../../src/file-manager";
+
+describe("FileManager - Constructor Parameter", () => {
+  describe("Constructor", () => {
+    it("should accept storeDirectory as constructor parameter", () => {
+      const storeDir = "custom-store";
+      const fileManager = new FileManager(storeDir);
+      expect(fileManager).toBeDefined();
+    });
+
+    it("should throw error when storeDirectory is undefined", () => {
+      // This test verifies constructor validates the parameter
+      expect(() => new FileManager(undefined as unknown as string)).toThrow(
+        "storeDirectory parameter is required",
+      );
+    });
+
+    it("should throw error when storeDirectory is null", () => {
+      // This test verifies constructor validates against null
+      expect(() => new FileManager(null as unknown as string)).toThrow(
+        "storeDirectory parameter is required",
+      );
+    });
+
+    it("should throw error when storeDirectory is empty string", () => {
+      // This test verifies constructor validates against empty string
+      expect(() => new FileManager("")).toThrow(
+        "storeDirectory cannot be empty",
+      );
+    });
+  });
+});

--- a/__tests__/units/file-manager/store-directory-usage.test.ts
+++ b/__tests__/units/file-manager/store-directory-usage.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { FileManager } from "../../../src/file-manager";
+import { CHAIN_IDS } from "../../../src/types";
+
+describe("FileManager - Store Directory Usage", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "file-manager-test-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir("/");
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("Store Directory Configuration", () => {
+    it("should use the provided store directory for ensureStoreDirectory", () => {
+      const customDir = "my-custom-store";
+      const fileManager = new FileManager(customDir);
+
+      fileManager.ensureStoreDirectory();
+
+      // Should create the custom directory, not the hardcoded "store"
+      expect(fs.existsSync(customDir)).toBe(true);
+      expect(fs.existsSync("store")).toBe(false);
+    });
+
+    it("should use the provided store directory for block numbers file", () => {
+      const customDir = "data-store";
+      const fileManager = new FileManager(customDir);
+
+      const blockData = {
+        metadata: { chain_id: CHAIN_IDS.ARBITRUM_NOVA },
+        blocks: { "2024-01-15": 12345 },
+      };
+
+      fileManager.writeBlockNumbers(blockData);
+
+      // Should write to custom directory, not hardcoded "store"
+      expect(fs.existsSync(path.join(customDir, "block_numbers.json"))).toBe(
+        true,
+      );
+      expect(fs.existsSync(path.join("store", "block_numbers.json"))).toBe(
+        false,
+      );
+    });
+
+    it("should use the provided store directory for distributor files", () => {
+      const customDir = "distributor-data";
+      const address = "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9";
+      const fileManager = new FileManager(customDir);
+
+      const balanceData = {
+        metadata: {
+          chain_id: CHAIN_IDS.ARBITRUM_NOVA,
+          reward_distributor: address,
+        },
+        balances: {
+          "2024-01-15": {
+            block_number: 12345,
+            balance_wei: "1000000000000000000",
+          },
+        },
+      };
+
+      fileManager.writeDistributorBalances(address, balanceData);
+
+      // Should write to custom directory structure
+      const expectedPath = path.join(
+        customDir,
+        "distributors",
+        address,
+        "balances.json",
+      );
+      expect(fs.existsSync(expectedPath)).toBe(true);
+
+      // Should not create hardcoded "store" directory
+      expect(fs.existsSync("store")).toBe(false);
+    });
+
+    it("should support different store directories for different instances", () => {
+      const dir1 = "store1";
+      const dir2 = "store2";
+
+      const fileManager1 = new FileManager(dir1);
+      const fileManager2 = new FileManager(dir2);
+
+      fileManager1.ensureStoreDirectory();
+      fileManager2.ensureStoreDirectory();
+
+      expect(fs.existsSync(dir1)).toBe(true);
+      expect(fs.existsSync(dir2)).toBe(true);
+    });
+  });
+});

--- a/__tests__/units/file-manager/test-utils.ts
+++ b/__tests__/units/file-manager/test-utils.ts
@@ -19,7 +19,7 @@ export const MAX_UINT256 =
 
 // Test setup helpers
 export function setupFileManager(): FileManagerInterface {
-  return new FileManager();
+  return new FileManager("store");
 }
 
 export interface TestContext {

--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -11,7 +11,6 @@ import {
   DistributorType,
   BalanceData,
   OutflowData,
-  STORE_DIR,
   DISTRIBUTORS_DIR,
 } from "./types";
 
@@ -40,28 +39,43 @@ const EXAMPLE_WEI_VALUE = "1230000000000000000000";
 const WEI_DECIMAL_REGEX = /^\d+$/;
 
 export class FileManager implements FileManagerInterface {
+  private readonly storeDirectory: string;
+
+  constructor(storeDirectory: string) {
+    if (storeDirectory === undefined || storeDirectory === null) {
+      throw new Error("storeDirectory parameter is required");
+    }
+    if (storeDirectory === "") {
+      throw new Error("storeDirectory cannot be empty");
+    }
+    this.storeDirectory = storeDirectory;
+  }
+
   readBlockNumbers(): BlockNumberData | undefined {
     return this.readJsonFileOrUndefined(
-      path.join(STORE_DIR, BLOCK_NUMBERS_FILE),
+      path.join(this.storeDirectory, BLOCK_NUMBERS_FILE),
     );
   }
 
   writeBlockNumbers(data: BlockNumberData): void {
     this.validateBlockNumberData(data);
     this.ensureStoreDirectory();
-    this.writeJsonFile(path.join(STORE_DIR, BLOCK_NUMBERS_FILE), data);
+    this.writeJsonFile(
+      path.join(this.storeDirectory, BLOCK_NUMBERS_FILE),
+      data,
+    );
   }
 
   readDistributors(): DistributorsData | undefined {
     return this.readJsonFileOrUndefined(
-      path.join(STORE_DIR, DISTRIBUTORS_FILE),
+      path.join(this.storeDirectory, DISTRIBUTORS_FILE),
     );
   }
 
   writeDistributors(data: DistributorsData): void {
     this.validateDistributorsData(data);
     this.ensureStoreDirectory();
-    this.writeJsonFile(path.join(STORE_DIR, DISTRIBUTORS_FILE), data);
+    this.writeJsonFile(path.join(this.storeDirectory, DISTRIBUTORS_FILE), data);
   }
 
   readDistributorBalances(address: Address): BalanceData | undefined {
@@ -99,8 +113,8 @@ export class FileManager implements FileManagerInterface {
   }
 
   ensureStoreDirectory(): void {
-    if (!fs.existsSync(STORE_DIR)) {
-      fs.mkdirSync(STORE_DIR, { recursive: true });
+    if (!fs.existsSync(this.storeDirectory)) {
+      fs.mkdirSync(this.storeDirectory, { recursive: true });
     }
   }
 
@@ -127,14 +141,14 @@ export class FileManager implements FileManagerInterface {
   }
 
   private ensureDistributorDirectory(address: Address): void {
-    const dirPath = path.join(STORE_DIR, DISTRIBUTORS_DIR, address);
+    const dirPath = path.join(this.storeDirectory, DISTRIBUTORS_DIR, address);
     if (!fs.existsSync(dirPath)) {
       fs.mkdirSync(dirPath, { recursive: true });
     }
   }
 
   private getDistributorFilePath(address: Address, fileName: string): string {
-    return path.join(STORE_DIR, DISTRIBUTORS_DIR, address, fileName);
+    return path.join(this.storeDirectory, DISTRIBUTORS_DIR, address, fileName);
   }
 
   private readJsonFileOrUndefined<T>(filePath: string): T | undefined {


### PR DESCRIPTION
## Summary
- Add required `storeDirectory` parameter to FileManager constructor (no default value)
- Replace all hardcoded STORE_DIR usage with instance property
- Update all FileManager instantiations to provide the directory parameter

## Test plan
- [x] Added unit tests for constructor parameter validation
- [x] Added integration tests for store directory usage
- [x] All existing tests pass with the refactored code
- [x] Verified FileManager correctly uses provided directory for all file operations

Closes #84