### PR TITLE
refactor: make FileManager accept store directory as constructor parameter

### DIFF
--- a/__tests__/units/file-manager/test-utils.ts
+++ b/__tests__/units/file-manager/test-utils.ts
@@ -2,7 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { FileManager } from "../../../src/file-manager";
-import { FileManager as FileManagerInterface } from "../../../src/types";
+import {
+  FileManager as FileManagerInterface,
+  STORE_DIR,
+} from "../../../src/types";
 
 // Common test constants
 export const VALID_ADDRESS = "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9";
@@ -19,7 +22,7 @@ export const MAX_UINT256 =
 
 // Test setup helpers
 export function setupFileManager(): FileManagerInterface {
-  return new FileManager();
+  return new FileManager(STORE_DIR);
 }
 
 export interface TestContext {

--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -11,7 +11,6 @@ import {
   DistributorType,
   BalanceData,
   OutflowData,
-  STORE_DIR,
   DISTRIBUTORS_DIR,
 } from "./types";
 
@@ -40,28 +39,37 @@ const EXAMPLE_WEI_VALUE = "1230000000000000000000";
 const WEI_DECIMAL_REGEX = /^\d+$/;
 
 export class FileManager implements FileManagerInterface {
+  private readonly storeDirectory: string;
+
+  constructor(storeDirectory: string) {
+    this.storeDirectory = storeDirectory;
+  }
+
   readBlockNumbers(): BlockNumberData | undefined {
     return this.readJsonFileOrUndefined(
-      path.join(STORE_DIR, BLOCK_NUMBERS_FILE),
+      path.join(this.storeDirectory, BLOCK_NUMBERS_FILE),
     );
   }
 
   writeBlockNumbers(data: BlockNumberData): void {
     this.validateBlockNumberData(data);
     this.ensureStoreDirectory();
-    this.writeJsonFile(path.join(STORE_DIR, BLOCK_NUMBERS_FILE), data);
+    this.writeJsonFile(
+      path.join(this.storeDirectory, BLOCK_NUMBERS_FILE),
+      data,
+    );
   }
 
   readDistributors(): DistributorsData | undefined {
     return this.readJsonFileOrUndefined(
-      path.join(STORE_DIR, DISTRIBUTORS_FILE),
+      path.join(this.storeDirectory, DISTRIBUTORS_FILE),
     );
   }
 
   writeDistributors(data: DistributorsData): void {
     this.validateDistributorsData(data);
     this.ensureStoreDirectory();
-    this.writeJsonFile(path.join(STORE_DIR, DISTRIBUTORS_FILE), data);
+    this.writeJsonFile(path.join(this.storeDirectory, DISTRIBUTORS_FILE), data);
   }
 
   readDistributorBalances(address: Address): BalanceData | undefined {
@@ -99,8 +107,8 @@ export class FileManager implements FileManagerInterface {
   }
 
   ensureStoreDirectory(): void {
-    if (!fs.existsSync(STORE_DIR)) {
-      fs.mkdirSync(STORE_DIR, { recursive: true });
+    if (!fs.existsSync(this.storeDirectory)) {
+      fs.mkdirSync(this.storeDirectory, { recursive: true });
     }
   }
 
@@ -127,14 +135,14 @@ export class FileManager implements FileManagerInterface {
   }
 
   private ensureDistributorDirectory(address: Address): void {
-    const dirPath = path.join(STORE_DIR, DISTRIBUTORS_DIR, address);
+    const dirPath = path.join(this.storeDirectory, DISTRIBUTORS_DIR, address);
     if (!fs.existsSync(dirPath)) {
       fs.mkdirSync(dirPath, { recursive: true });
     }
   }
 
   private getDistributorFilePath(address: Address, fileName: string): string {
-    return path.join(STORE_DIR, DISTRIBUTORS_DIR, address, fileName);
+    return path.join(this.storeDirectory, DISTRIBUTORS_DIR, address, fileName);
   }
 
   private readJsonFileOrUndefined<T>(filePath: string): T | undefined {


### PR DESCRIPTION
## Summary
- Refactored FileManager to accept store directory as a required constructor parameter
- Removed hardcoded STORE_DIR usage from FileManager class
- Updated all FileManager instantiations to provide the store directory

## Context
This change addresses issue #84 to make the FileManager more flexible for different environments (testing, production, development) and to improve test isolation.

## Breaking Changes
**BREAKING CHANGE**: FileManager now requires a store directory parameter in its constructor. All code that instantiates FileManager must be updated to provide this parameter.

## Implementation Details
- Added `storeDirectory` private property to FileManager class
- Added constructor that requires `storeDirectory` parameter
- Replaced all `STORE_DIR` references with `this.storeDirectory`
- Updated test utilities to pass `STORE_DIR` when creating FileManager instances
- Removed `STORE_DIR` import from FileManager class

## Test plan
- [x] All existing unit tests pass
- [x] All existing integration tests pass
- [x] TypeScript compilation succeeds
- [x] ESLint passes
- [x] Code formatting is correct

Resolves #84