### PR TITLE
feat: implement getDistributorType static method

### DIFF
--- a/__tests__/units/distributor-detector/get-distributor-type.test.ts
+++ b/__tests__/units/distributor-detector/get-distributor-type.test.ts
@@ -9,5 +9,12 @@ describe("DistributorDetector.getDistributorType", () => {
       );
       expect(result).toBe(DistributorType.L2_BASE_FEE);
     });
+
+    it("returns L2_SURPLUS_FEE for setL2SurplusFeeRewardRecipient signature", () => {
+      const result = DistributorDetector.getDistributorType(
+        DISTRIBUTOR_METHODS.L2_SURPLUS_FEE,
+      );
+      expect(result).toBe(DistributorType.L2_SURPLUS_FEE);
+    });
   });
 });

--- a/__tests__/units/distributor-detector/get-distributor-type.test.ts
+++ b/__tests__/units/distributor-detector/get-distributor-type.test.ts
@@ -1,0 +1,13 @@
+import { DistributorDetector } from "../../../src/distributor-detector";
+import { DistributorType, DISTRIBUTOR_METHODS } from "../../../src/types";
+
+describe("DistributorDetector.getDistributorType", () => {
+  describe("Method signature mapping", () => {
+    it("returns L2_BASE_FEE for setL2BaseFeeRewardRecipient signature", () => {
+      const result = DistributorDetector.getDistributorType(
+        DISTRIBUTOR_METHODS.L2_BASE_FEE,
+      );
+      expect(result).toBe(DistributorType.L2_BASE_FEE);
+    });
+  });
+});

--- a/__tests__/units/distributor-detector/get-distributor-type.test.ts
+++ b/__tests__/units/distributor-detector/get-distributor-type.test.ts
@@ -24,4 +24,11 @@ describe("DistributorDetector.getDistributorType", () => {
       expect(result).toBe(DistributorType.L1_SURPLUS_FEE);
     });
   });
+
+  describe("Unknown signatures", () => {
+    it("returns null for unknown method signature", () => {
+      const result = DistributorDetector.getDistributorType("0x12345678");
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/__tests__/units/distributor-detector/get-distributor-type.test.ts
+++ b/__tests__/units/distributor-detector/get-distributor-type.test.ts
@@ -16,5 +16,12 @@ describe("DistributorDetector.getDistributorType", () => {
       );
       expect(result).toBe(DistributorType.L2_SURPLUS_FEE);
     });
+
+    it("returns L1_SURPLUS_FEE for setL1SurplusFeeRewardRecipient signature", () => {
+      const result = DistributorDetector.getDistributorType(
+        DISTRIBUTOR_METHODS.L1_SURPLUS_FEE,
+      );
+      expect(result).toBe(DistributorType.L1_SURPLUS_FEE);
+    });
   });
 });

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -1,0 +1,9 @@
+import { DistributorType } from "./types";
+
+export class DistributorDetector {
+  static getDistributorType(methodSignature: string): DistributorType | null {
+    // Suppress unused variable warning for TDD stub
+    void methodSignature;
+    throw new Error("Not implemented");
+  }
+}

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -2,7 +2,9 @@ import { DistributorType } from "./types";
 
 export class DistributorDetector {
   static getDistributorType(methodSignature: string): DistributorType | null {
-    void methodSignature; // Minimal implementation - ignore parameter for now
-    return DistributorType.L2_BASE_FEE;
+    if (methodSignature === "0x57f585db") {
+      return DistributorType.L2_BASE_FEE;
+    }
+    return DistributorType.L2_SURPLUS_FEE;
   }
 }

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -5,6 +5,9 @@ export class DistributorDetector {
     if (methodSignature === "0x57f585db") {
       return DistributorType.L2_BASE_FEE;
     }
-    return DistributorType.L2_SURPLUS_FEE;
+    if (methodSignature === "0xfcdde2b4") {
+      return DistributorType.L2_SURPLUS_FEE;
+    }
+    return DistributorType.L1_SURPLUS_FEE;
   }
 }

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -2,8 +2,7 @@ import { DistributorType } from "./types";
 
 export class DistributorDetector {
   static getDistributorType(methodSignature: string): DistributorType | null {
-    // Suppress unused variable warning for TDD stub
-    void methodSignature;
-    throw new Error("Not implemented");
+    void methodSignature; // Minimal implementation - ignore parameter for now
+    return DistributorType.L2_BASE_FEE;
   }
 }

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -1,16 +1,16 @@
-import { DistributorType } from "./types";
+import { DistributorType, DISTRIBUTOR_METHODS } from "./types";
 
 export class DistributorDetector {
   static getDistributorType(methodSignature: string): DistributorType | null {
-    if (methodSignature === "0x57f585db") {
-      return DistributorType.L2_BASE_FEE;
+    switch (methodSignature) {
+      case DISTRIBUTOR_METHODS.L2_BASE_FEE:
+        return DistributorType.L2_BASE_FEE;
+      case DISTRIBUTOR_METHODS.L2_SURPLUS_FEE:
+        return DistributorType.L2_SURPLUS_FEE;
+      case DISTRIBUTOR_METHODS.L1_SURPLUS_FEE:
+        return DistributorType.L1_SURPLUS_FEE;
+      default:
+        return null;
     }
-    if (methodSignature === "0xfcdde2b4") {
-      return DistributorType.L2_SURPLUS_FEE;
-    }
-    if (methodSignature === "0x934be07d") {
-      return DistributorType.L1_SURPLUS_FEE;
-    }
-    return null;
   }
 }

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -8,6 +8,9 @@ export class DistributorDetector {
     if (methodSignature === "0xfcdde2b4") {
       return DistributorType.L2_SURPLUS_FEE;
     }
-    return DistributorType.L1_SURPLUS_FEE;
+    if (methodSignature === "0x934be07d") {
+      return DistributorType.L1_SURPLUS_FEE;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- Implemented static method `getDistributorType` on the DistributorDetector class
- Maps method signatures to corresponding DistributorType enum values
- Returns null for unknown signatures

## Implementation Details
Following TDD process (RED → GREEN → REFACTOR):
- Created comprehensive test coverage for all distributor types and edge cases
- Implemented minimal code to pass tests incrementally
- Refactored to use existing constants and switch statement for clarity

## Test Coverage
✅ Maps `0x57f585db` → `L2_BASE_FEE`
✅ Maps `0xfcdde2b4` → `L2_SURPLUS_FEE`
✅ Maps `0x934be07d` → `L1_SURPLUS_FEE`
✅ Returns `null` for unknown signatures

Closes #104