### PR TITLE
feat: implement DistributorDetector.isRewardDistributor static method

### DIFF
--- a/__tests__/units/distributor-detector/is-reward-distributor.test.ts
+++ b/__tests__/units/distributor-detector/is-reward-distributor.test.ts
@@ -1,0 +1,75 @@
+import { ethers } from "ethers";
+import { DistributorDetector } from "../../../src/distributor-detector";
+import { REWARD_DISTRIBUTOR_BYTECODE } from "../../../src/constants/reward-distributor-bytecode";
+
+describe("DistributorDetector.isRewardDistributor", () => {
+  let mockProvider: jest.Mocked<ethers.Provider>;
+
+  beforeEach(() => {
+    mockProvider = {
+      getCode: jest.fn(),
+    } as unknown as jest.Mocked<ethers.Provider>;
+  });
+
+  describe("Valid reward distributor", () => {
+    it("returns true when bytecode matches REWARD_DISTRIBUTOR_BYTECODE", async () => {
+      const testAddress = "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce";
+      mockProvider.getCode.mockResolvedValue(REWARD_DISTRIBUTOR_BYTECODE);
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        testAddress,
+      );
+
+      expect(result).toBe(true);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
+    });
+  });
+
+  describe("Non-reward distributor contract", () => {
+    it("returns false when bytecode does not match", async () => {
+      const testAddress = "0x1234567890123456789012345678901234567890";
+      const differentBytecode =
+        "0x608060405234801561001057600080fd5b50610150806100206000396000f3fe";
+      mockProvider.getCode.mockResolvedValue(differentBytecode);
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        testAddress,
+      );
+
+      expect(result).toBe(false);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
+    });
+  });
+
+  describe("Address with no deployed code", () => {
+    it("returns false for EOA (externally owned account)", async () => {
+      const eoaAddress = "0xabc1234567890123456789012345678901234567";
+      mockProvider.getCode.mockResolvedValue("0x");
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        eoaAddress,
+      );
+
+      expect(result).toBe(false);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(eoaAddress);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("returns false when provider.getCode throws an error", async () => {
+      const testAddress = "0x1234567890123456789012345678901234567890";
+      mockProvider.getCode.mockRejectedValue(new Error("Network error"));
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        testAddress,
+      );
+
+      expect(result).toBe(false);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
+    });
+  });
+});

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -1,4 +1,6 @@
+import { ethers } from "ethers";
 import { DistributorType, DISTRIBUTOR_METHODS } from "./types";
+import { REWARD_DISTRIBUTOR_BYTECODE } from "./constants/reward-distributor-bytecode";
 
 export class DistributorDetector {
   static getDistributorType(methodSignature: string): DistributorType | null {
@@ -11,6 +13,18 @@ export class DistributorDetector {
         return DistributorType.L1_SURPLUS_FEE;
       default:
         return null;
+    }
+  }
+
+  static async isRewardDistributor(
+    provider: ethers.Provider,
+    address: string,
+  ): Promise<boolean> {
+    try {
+      const deployedCode = await provider.getCode(address);
+      return deployedCode === REWARD_DISTRIBUTOR_BYTECODE;
+    } catch {
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Implements the `isRewardDistributor` static method on the DistributorDetector class
- Verifies whether discovered addresses are valid reward distributors by comparing their deployed bytecode
- Helps identify if ArbOwner set a non-standard contract as distributor

## Implementation Details
- Method takes an ethers.Provider and contract address as parameters
- Fetches deployed bytecode using `provider.getCode(address)`
- Compares bytecode against REWARD_DISTRIBUTOR_BYTECODE constant
- Returns boolean: true if exact match, false otherwise
- Handles errors gracefully (returns false if address has no code or network error)

## Test plan
- [x] Test with valid reward distributor bytecode - returns true
- [x] Test with non-reward distributor contract - returns false  
- [x] Test with address that has no deployed code (EOA) - returns false
- [x] Test error handling when provider.getCode throws - returns false
- [x] All tests pass
- [x] Lint and typecheck pass

Closes #106