### PR TITLE
feat: integrate retry logic for RPC calls in distributor detector

### DIFF
--- a/__tests__/units/distributor-detector/is-reward-distributor.test.ts
+++ b/__tests__/units/distributor-detector/is-reward-distributor.test.ts
@@ -1,6 +1,12 @@
 import { ethers } from "ethers";
 import { DistributorDetector } from "../../../src/distributor-detector";
 import { REWARD_DISTRIBUTOR_BYTECODE } from "../../../src/constants/reward-distributor-bytecode";
+import { withRetry } from "../../../src/utils/retry";
+
+// Mock the retry utility
+jest.mock("../../../src/utils/retry", () => ({
+  withRetry: jest.fn((operation) => operation()),
+}));
 
 describe("DistributorDetector.isRewardDistributor", () => {
   let mockProvider: jest.Mocked<ethers.Provider>;
@@ -9,6 +15,9 @@ describe("DistributorDetector.isRewardDistributor", () => {
     mockProvider = {
       getCode: jest.fn(),
     } as unknown as jest.Mocked<ethers.Provider>;
+
+    // Reset the retry mock
+    (withRetry as jest.Mock).mockImplementation((operation) => operation());
   });
 
   describe("Valid reward distributor", () => {
@@ -69,6 +78,98 @@ describe("DistributorDetector.isRewardDistributor", () => {
       );
 
       expect(result).toBe(false);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
+    });
+  });
+
+  describe("Retry logic", () => {
+    it("uses withRetry wrapper for provider.getCode calls", async () => {
+      const testAddress = "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce";
+      mockProvider.getCode.mockResolvedValue(REWARD_DISTRIBUTOR_BYTECODE);
+
+      await DistributorDetector.isRewardDistributor(mockProvider, testAddress);
+
+      expect(withRetry).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          maxRetries: 3,
+          operationName: `isRewardDistributor.getCode(${testAddress})`,
+        }),
+      );
+    });
+
+    it("retries on transient errors and eventually succeeds", async () => {
+      const testAddress = "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce";
+
+      // Mock withRetry to simulate retry behavior
+      (withRetry as jest.Mock).mockImplementation(async (operation) => {
+        // Simulate multiple attempts
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            return await operation();
+          } catch (error) {
+            if (attempt === 2) {
+              // Succeed on third attempt
+              mockProvider.getCode.mockResolvedValueOnce(
+                REWARD_DISTRIBUTOR_BYTECODE,
+              );
+            }
+            if (attempt < 2) {
+              continue;
+            }
+            throw error;
+          }
+        }
+      });
+
+      mockProvider.getCode
+        .mockRejectedValueOnce(new Error("Network timeout"))
+        .mockRejectedValueOnce(new Error("Connection reset"))
+        .mockResolvedValueOnce(REWARD_DISTRIBUTOR_BYTECODE);
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        testAddress,
+      );
+
+      expect(result).toBe(true);
+      expect(mockProvider.getCode).toHaveBeenCalledTimes(3);
+      expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
+    });
+
+    it("returns false after exhausting all retry attempts", async () => {
+      const testAddress = "0x1234567890123456789012345678901234567890";
+
+      // Mock withRetry to simulate exhausting retries
+      (withRetry as jest.Mock).mockRejectedValue(
+        new Error("Network error after 3 retries"),
+      );
+
+      mockProvider.getCode.mockRejectedValue(new Error("Persistent error"));
+
+      const result = await DistributorDetector.isRewardDistributor(
+        mockProvider,
+        testAddress,
+      );
+
+      expect(result).toBe(false);
+      expect(withRetry).toHaveBeenCalled();
+    });
+
+    it("passes correct retry configuration", async () => {
+      const testAddress = "0xabc1234567890123456789012345678901234567";
+      mockProvider.getCode.mockResolvedValue("0x");
+
+      await DistributorDetector.isRewardDistributor(mockProvider, testAddress);
+
+      expect(withRetry).toHaveBeenCalledWith(expect.any(Function), {
+        maxRetries: 3,
+        operationName: `isRewardDistributor.getCode(${testAddress})`,
+      });
+
+      // Verify the wrapped function is correct
+      const wrappedFunction = (withRetry as jest.Mock).mock.calls[0][0];
+      await wrappedFunction();
       expect(mockProvider.getCode).toHaveBeenCalledWith(testAddress);
     });
   });

--- a/src/distributor-detector.ts
+++ b/src/distributor-detector.ts
@@ -45,7 +45,10 @@ export class DistributorDetector {
     address: string,
   ): Promise<boolean> {
     try {
-      const deployedCode = await provider.getCode(address);
+      const deployedCode = await withRetry(() => provider.getCode(address), {
+        maxRetries: 3,
+        operationName: `isRewardDistributor.getCode(${address})`,
+      });
       return deployedCode === REWARD_DISTRIBUTOR_BYTECODE;
     } catch {
       return false;


### PR DESCRIPTION
## Summary
- Adds retry logic to `provider.getCode()` calls in the `isRewardDistributor` method
- Improves reliability when handling transient network failures
- Follows existing retry patterns used in other RPC calls within the same component

## Changes
- Wrapped `provider.getCode()` call with `withRetry` utility in `DistributorDetector.isRewardDistributor`
- Added comprehensive tests for retry behavior including:
  - Verification that withRetry is used correctly
  - Testing retry on transient errors
  - Testing max retry attempts
  - Testing retry configuration

## Test plan
- [x] Added new tests for retry logic in `isRewardDistributor`
- [x] All existing tests continue to pass
- [x] Manual testing shows retry behavior works as expected
- [x] Linting and type checking pass

Fixes #111