### PR TITLE
refactor: replace hardcoded RPC URLs with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# RPC URLs for testing
+ARBITRUM_NOVA_RPC_URL=https://nova.arbitrum.io/rpc

--- a/__tests__/integration/distributor-detector-integration.test.ts
+++ b/__tests__/integration/distributor-detector-integration.test.ts
@@ -20,7 +20,7 @@ import { ARBOWNER_PRECOMPILE_ADDRESS } from "../../src/constants/distributor-det
 
 // Network configuration for Nova RPC
 const ARBITRUM_NOVA_CHAIN_ID = 42170;
-const ARBITRUM_NOVA_RPC_URL = "https://nova.arbitrum.io/rpc";
+const ARBITRUM_NOVA_RPC_URL = process.env["ARBITRUM_NOVA_RPC_URL"] as string;
 const NETWORK_CONFIG = {
   chainId: ARBITRUM_NOVA_CHAIN_ID,
   name: "arbitrum-nova",

--- a/__tests__/units/block-finder/test-utils.ts
+++ b/__tests__/units/block-finder/test-utils.ts
@@ -4,7 +4,9 @@ import { BlockFinder } from "../../../src/block-finder";
 
 // Network configuration
 export const ARBITRUM_NOVA_CHAIN_ID = 42170;
-export const ARBITRUM_NOVA_RPC_URL = "https://nova.arbitrum.io/rpc";
+export const ARBITRUM_NOVA_RPC_URL = process.env[
+  "ARBITRUM_NOVA_RPC_URL"
+] as string;
 export const NETWORK_CONFIG = {
   chainId: ARBITRUM_NOVA_CHAIN_ID,
   name: "arbitrum-nova",
@@ -16,7 +18,7 @@ export const LOCALHOST_RPC = "http://localhost:9999";
 
 // Provider creation helpers
 export function createProvider(
-  rpcUrl: string = ARBITRUM_NOVA_RPC_URL,
+  rpcUrl: string = process.env["ARBITRUM_NOVA_RPC_URL"] as string,
 ): ethers.JsonRpcProvider {
   const network = ethers.Network.from(NETWORK_CONFIG);
   return new ethers.JsonRpcProvider(rpcUrl, network, {
@@ -25,7 +27,7 @@ export function createProvider(
 }
 
 export function createMockProvider(
-  rpcUrl: string = ARBITRUM_NOVA_RPC_URL,
+  rpcUrl: string = process.env["ARBITRUM_NOVA_RPC_URL"] as string,
 ): ethers.JsonRpcProvider {
   return createProvider(rpcUrl);
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,5 +34,6 @@ module.exports = {
   clearMocks: true,
   restoreMocks: true,
   testTimeout: 10000,
-  maxConcurrency: 10
+  maxConcurrency: 10,
+  setupFiles: ['<rootDir>/jest.setup.js']
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+// Load environment variables from .env file for tests
+require('dotenv').config();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "dotenv": "^16.5.0",
         "ethers": "^6.14.3"
       },
       "devDependencies": {
@@ -2812,6 +2813,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotgitignore": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
     "ethers": "^6.14.3"
   }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded Arbitrum Nova RPC URL with environment variable `ARBITRUM_NOVA_RPC_URL`
- Create `.env.example` file documenting the required environment variable
- Update test utilities and integration tests to read from `process.env`

## Motivation
Moving RPC URLs to environment variables improves:
- **Flexibility**: Run tests against different networks without code changes
- **Security**: Prevents accidental commits of sensitive RPC endpoints
- **Configuration**: Easier to manage different environments (dev/staging/prod)

## Changes
1. Created `.env.example` with `ARBITRUM_NOVA_RPC_URL` variable
2. Updated `__tests__/units/block-finder/test-utils.ts` to use `process.env["ARBITRUM_NOVA_RPC_URL"]`
3. Updated `__tests__/integration/distributor-detector-integration.test.ts` to use environment variable
4. `.gitignore` already excludes `.env` files (verified)

## Testing
Tests now require the `ARBITRUM_NOVA_RPC_URL` environment variable to be set:
```bash
ARBITRUM_NOVA_RPC_URL="https://nova.arbitrum.io/rpc" npm test
```

## Notes
- No backward compatibility was added per project guidelines
- Chain ID remains hardcoded as specified in issue #137
- Documentation files contain RPC URLs but were left unchanged as they serve as examples

Closes #137