### PR TITLE
chore: update .gitignore to exclude auth config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ UPDATES.md
 
 # NPM packages
 *.tgz
+
+# Auth config and scripts
+auth_config_snapshots/
+capture-auth-changes.sh


### PR DESCRIPTION
## Summary
- Add `auth_config_snapshots/` directory to .gitignore
- Add `capture-auth-changes.sh` script to .gitignore
- Prevents auth configuration files from being tracked in version control

no-issue: routine maintenance to update .gitignore

## Test plan
- [x] Verified .gitignore entries are correctly formatted
- [x] Confirmed unstaged files will be ignored after these changes
- [x] All tests pass