### PR TITLE
refactor: replace hardcoded RPC URLs with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# RPC URLs for testing
+# Copy this file to .env and update with your preferred RPC endpoints
+# These are required for running tests that interact with blockchain networks
+
+# Arbitrum Nova RPC URL - required for block finder and distributor detector tests
+ARBITRUM_NOVA_RPC_URL=https://nova.arbitrum.io/rpc

--- a/__tests__/integration/distributor-detector-integration.test.ts
+++ b/__tests__/integration/distributor-detector-integration.test.ts
@@ -20,7 +20,8 @@ import { ARBOWNER_PRECOMPILE_ADDRESS } from "../../src/constants/distributor-det
 
 // Network configuration for Nova RPC
 const ARBITRUM_NOVA_CHAIN_ID = 42170;
-const ARBITRUM_NOVA_RPC_URL = "https://nova.arbitrum.io/rpc";
+// RPC URL must be set via ARBITRUM_NOVA_RPC_URL environment variable
+const ARBITRUM_NOVA_RPC_URL = process.env["ARBITRUM_NOVA_RPC_URL"]!;
 const NETWORK_CONFIG = {
   chainId: ARBITRUM_NOVA_CHAIN_ID,
   name: "arbitrum-nova",
@@ -28,6 +29,9 @@ const NETWORK_CONFIG = {
 
 // Helper to create Nova provider
 function createNovaProvider(): ethers.JsonRpcProvider {
+  if (!ARBITRUM_NOVA_RPC_URL) {
+    throw new Error("ARBITRUM_NOVA_RPC_URL environment variable must be set");
+  }
   const network = ethers.Network.from(NETWORK_CONFIG);
   return new ethers.JsonRpcProvider(ARBITRUM_NOVA_RPC_URL, network, {
     staticNetwork: network,

--- a/__tests__/units/block-finder/test-utils.test.ts
+++ b/__tests__/units/block-finder/test-utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+describe("test-utils environment configuration", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    // Clear the module cache to ensure fresh imports
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  describe("ARBITRUM_NOVA_RPC_URL", () => {
+    it("should use RPC URL from ARBITRUM_NOVA_RPC_URL environment variable", () => {
+      const testRpcUrl = "https://test-rpc.example.com";
+      process.env["ARBITRUM_NOVA_RPC_URL"] = testRpcUrl;
+
+      // Re-import to get updated env value
+      jest.isolateModules(() => {
+        const testUtils = require("./test-utils");
+        expect(testUtils.ARBITRUM_NOVA_RPC_URL).toBe(testRpcUrl);
+      });
+    });
+
+    it("should be undefined when environment variable is not set", () => {
+      delete process.env["ARBITRUM_NOVA_RPC_URL"];
+
+      jest.isolateModules(() => {
+        const testUtils = require("./test-utils");
+        expect(testUtils.ARBITRUM_NOVA_RPC_URL).toBeUndefined();
+      });
+    });
+  });
+
+  describe("createProvider", () => {
+    it("should use environment variable RPC URL by default", () => {
+      const testRpcUrl = "https://env-test-rpc.example.com";
+      process.env["ARBITRUM_NOVA_RPC_URL"] = testRpcUrl;
+
+      jest.isolateModules(() => {
+        const testUtils = require("./test-utils");
+        const provider = testUtils.createProvider();
+
+        // In ethers v6, check the _request property
+        expect(provider._getConnection().url).toBe(testRpcUrl);
+      });
+    });
+
+    it("should throw error when no RPC URL provided and env var not set", () => {
+      delete process.env["ARBITRUM_NOVA_RPC_URL"];
+
+      jest.isolateModules(() => {
+        const testUtils = require("./test-utils");
+        expect(() => testUtils.createProvider()).toThrow();
+      });
+    });
+
+    it("should allow overriding with explicit RPC URL parameter", () => {
+      const overrideUrl = "https://override-rpc.example.com";
+      process.env["ARBITRUM_NOVA_RPC_URL"] = "https://env-rpc.example.com";
+
+      jest.isolateModules(() => {
+        const testUtils = require("./test-utils");
+        const provider = testUtils.createProvider(overrideUrl);
+        expect(provider._getConnection().url).toBe(overrideUrl);
+      });
+    });
+  });
+});

--- a/__tests__/units/block-finder/test-utils.ts
+++ b/__tests__/units/block-finder/test-utils.ts
@@ -4,7 +4,8 @@ import { BlockFinder } from "../../../src/block-finder";
 
 // Network configuration
 export const ARBITRUM_NOVA_CHAIN_ID = 42170;
-export const ARBITRUM_NOVA_RPC_URL = "https://nova.arbitrum.io/rpc";
+// RPC URL must be set via ARBITRUM_NOVA_RPC_URL environment variable
+export const ARBITRUM_NOVA_RPC_URL = process.env["ARBITRUM_NOVA_RPC_URL"]!;
 export const NETWORK_CONFIG = {
   chainId: ARBITRUM_NOVA_CHAIN_ID,
   name: "arbitrum-nova",
@@ -15,19 +16,21 @@ export const INVALID_RPC = "https://invalid-rpc-url.com";
 export const LOCALHOST_RPC = "http://localhost:9999";
 
 // Provider creation helpers
-export function createProvider(
-  rpcUrl: string = ARBITRUM_NOVA_RPC_URL,
-): ethers.JsonRpcProvider {
+export function createProvider(rpcUrl?: string): ethers.JsonRpcProvider {
+  const url = rpcUrl || ARBITRUM_NOVA_RPC_URL;
+  if (!url) {
+    throw new Error(
+      "RPC URL must be provided or ARBITRUM_NOVA_RPC_URL environment variable must be set",
+    );
+  }
   const network = ethers.Network.from(NETWORK_CONFIG);
-  return new ethers.JsonRpcProvider(rpcUrl, network, {
+  return new ethers.JsonRpcProvider(url, network, {
     staticNetwork: network,
   });
 }
 
-export function createMockProvider(
-  rpcUrl: string = ARBITRUM_NOVA_RPC_URL,
-): ethers.JsonRpcProvider {
-  return createProvider(rpcUrl);
+export function createMockProvider(rpcUrl?: string): ethers.JsonRpcProvider {
+  return createProvider(rpcUrl || ARBITRUM_NOVA_RPC_URL);
 }
 
 // BlockFinder creation helpers


### PR DESCRIPTION
## Summary
- Replace hardcoded Nova RPC URL with `ARBITRUM_NOVA_RPC_URL` environment variable
- Add `.env.example` file documenting required environment variables  
- Improve flexibility for running tests against different RPC endpoints

## Test plan
- [x] Add unit tests verifying environment variable usage
- [x] Run all existing tests with `ARBITRUM_NOVA_RPC_URL` set
- [x] Verify tests fail gracefully when env var is not set
- [x] Ensure CI/CD will need to set this environment variable

Resolves #137