### PR TITLE
Feat: Implement fetchBalances method signature

### DIFF
--- a/__tests__/units/balance-fetcher.test.ts
+++ b/__tests__/units/balance-fetcher.test.ts
@@ -30,4 +30,38 @@ describe("BalanceFetcher", () => {
       expect(fetcher.provider).toBe(mockProvider);
     });
   });
+
+  describe("fetchBalances", () => {
+    let fetcher: BalanceFetcher;
+
+    beforeEach(() => {
+      fetcher = new BalanceFetcher(mockFileManager, mockProvider);
+    });
+
+    it("exists as a method on BalanceFetcher instance", () => {
+      expect(fetcher.fetchBalances).toBeDefined();
+      expect(typeof fetcher.fetchBalances).toBe("function");
+    });
+
+    it("accepts optional distributorAddress parameter", () => {
+      expect(fetcher.fetchBalances.length).toBeLessThanOrEqual(1);
+    });
+
+    it("returns a Promise", () => {
+      const result = fetcher.fetchBalances();
+      expect(result).toBeInstanceOf(Promise);
+      result.catch(() => {}); // Prevent unhandled promise rejection
+    });
+
+    it("throws 'Not implemented' error when called without parameters", async () => {
+      await expect(fetcher.fetchBalances()).rejects.toThrow("Not implemented");
+    });
+
+    it("throws 'Not implemented' error when called with distributorAddress", async () => {
+      const distributorAddress = "0x1234567890123456789012345678901234567890";
+      await expect(fetcher.fetchBalances(distributorAddress)).rejects.toThrow(
+        "Not implemented",
+      );
+    });
+  });
 });

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -12,4 +12,16 @@ export class BalanceFetcher {
     public readonly fileManager: FileManager,
     public readonly provider: ethers.Provider,
   ) {}
+
+  /**
+   * Fetch balances for all distributors or a specific distributor at all tracked dates.
+   *
+   * @param distributorAddress - If provided, only fetch balances for this specific distributor
+   * @returns Promise that resolves when all balances are fetched successfully
+   * @throws Error on any failure
+   */
+  async fetchBalances(distributorAddress?: string): Promise<void> {
+    void distributorAddress; // Satisfy linter
+    throw new Error("Not implemented");
+  }
 }

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -14,10 +14,11 @@ export class BalanceFetcher {
   ) {}
 
   /**
-   * Fetch balances for all distributors or a specific distributor at all tracked dates.
+   * Fetches missing balances for all distributors or a specific distributor.
+   * Uses incremental processing to only fetch balances for dates that haven't been fetched yet.
    *
    * @param distributorAddress - If provided, only fetch balances for this specific distributor
-   * @returns Promise that resolves when all balances are fetched successfully
+   * @returns Promise that resolves when all missing balances are fetched successfully
    * @throws Error on any failure
    */
   async fetchBalances(distributorAddress?: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `fetchBalances` method signature to BalanceFetcher class
- Method accepts optional `distributorAddress` parameter
- Returns `Promise<void>` as specified in balance-fetcher.md Section 5

## Test plan
✅ Unit tests added to verify:
- Method exists on BalanceFetcher instance
- Accepts optional distributorAddress parameter
- Returns a Promise
- Throws "Not implemented" error when called

All tests pass, linting passes, and type checking passes.

Resolves #146