### PR TITLE
Feat: Add distributor creation block to fetch list

### DIFF
--- a/__tests__/units/balance-fetcher.test.ts
+++ b/__tests__/units/balance-fetcher.test.ts
@@ -347,14 +347,14 @@ describe("BalanceFetcher", () => {
       mockDistributorsData = {
         metadata: {
           chain_id: 42170,
-          arbowner_address: "0x0000000000000000000000000000000000000070",
+          arbowner_address: "0x0000000000000000000000000000000000000000000070",
           last_scanned_block: 1000,
         },
         distributors: {
           "0xdff90519a9DE6ad469D4f9839a9220C5D340B792": {
             type: DistributorType.L2_BASE_FEE,
             block: 684,
-            date: "2022-08-09",
+            date: "2022-08-10", // Changed to a date NOT in block numbers
             tx_hash:
               "0x966831a2207df808ffcc44c90c0e60bce86185fb73b18c962f4f1303eb54efa2",
             method: "0x57f585db",
@@ -373,12 +373,11 @@ describe("BalanceFetcher", () => {
 
       await fetcher.fetchBalances();
 
-      // Should fetch balance for creation block 684 as well as end-of-day block 3584
+      // Should fetch balance for creation block 684 when date not in block numbers
       const calls = mockProvider.getBalance.mock.calls;
       const blocksCalled = calls.map((call) => call[1]);
 
       expect(blocksCalled).toContain(684); // Creation block
-      expect(blocksCalled).toContain(3584); // End-of-day block for same date
     });
 
     it("does not duplicate fetch when creation date already has end-of-day block", async () => {
@@ -473,14 +472,14 @@ describe("BalanceFetcher", () => {
       const calls = mockProvider.getBalance.mock.calls;
       const blocksCalled = calls.map((call) => call[1]);
 
-      // Find the position of the creation blocks
-      const creationBlock1Position = blocksCalled.indexOf(4000); // 2022-08-10
-      const creationBlock2Position = blocksCalled.indexOf(3163115); // 2023-03-16
+      // Find the position of blocks for our dates
+      const creationBlock1Position = blocksCalled.indexOf(4000); // 2022-08-10 creation block
+      const endOfDayBlock2Position = blocksCalled.indexOf(3166694); // 2023-03-16 end-of-day block
 
-      // Creation block from 2022-08-10 should come before 2023-03-16
+      // 2022-08-10 (creation block 4000) should come before 2023-03-16 blocks
       expect(creationBlock1Position).toBeGreaterThanOrEqual(0);
-      expect(creationBlock2Position).toBeGreaterThanOrEqual(0);
-      expect(creationBlock1Position).toBeLessThan(creationBlock2Position);
+      expect(endOfDayBlock2Position).toBeGreaterThanOrEqual(0);
+      expect(creationBlock1Position).toBeLessThan(endOfDayBlock2Position);
     });
   });
 

--- a/__tests__/units/balance-fetcher.test.ts
+++ b/__tests__/units/balance-fetcher.test.ts
@@ -308,6 +308,182 @@ describe("BalanceFetcher", () => {
     });
   });
 
+  describe("fetchBalances - adding creation blocks", () => {
+    let fetcher: BalanceFetcher;
+    let mockDistributorsData: DistributorsData;
+    let mockBlockNumberData: BlockNumberData;
+
+    beforeEach(() => {
+      mockFileManager = {
+        readDistributors: jest.fn(),
+        readBlockNumbers: jest.fn(),
+        readDistributorBalances: jest.fn(),
+        writeDistributorBalances: jest.fn(),
+      } as unknown as jest.Mocked<FileManager>;
+      mockProvider = {
+        getBalance: jest.fn(),
+      } as unknown as jest.Mocked<ethers.Provider>;
+      fetcher = new BalanceFetcher(mockFileManager, mockProvider);
+
+      mockBlockNumberData = {
+        metadata: {
+          chain_id: 42170,
+        },
+        blocks: {
+          "2022-07-11": 120,
+          "2022-07-12": 155,
+          "2022-07-13": 189,
+          "2022-08-07": 654,
+          "2022-08-08": 672,
+          "2022-08-09": 3584,
+          "2023-03-15": 3141957,
+          "2023-03-16": 3166694,
+          "2023-03-17": 3187362,
+        },
+      };
+    });
+
+    it("adds creation block to fetch list when creation date not in block numbers", async () => {
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0xdff90519a9DE6ad469D4f9839a9220C5D340B792": {
+            type: DistributorType.L2_BASE_FEE,
+            block: 684,
+            date: "2022-08-09",
+            tx_hash:
+              "0x966831a2207df808ffcc44c90c0e60bce86185fb73b18c962f4f1303eb54efa2",
+            method: "0x57f585db",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0xdff90519a9DE6ad469D4f9839a9220C5D340B792",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances();
+
+      // Should fetch balance for creation block 684 as well as end-of-day block 3584
+      const calls = mockProvider.getBalance.mock.calls;
+      const blocksCalled = calls.map((call) => call[1]);
+
+      expect(blocksCalled).toContain(684); // Creation block
+      expect(blocksCalled).toContain(3584); // End-of-day block for same date
+    });
+
+    it("does not duplicate fetch when creation date already has end-of-day block", async () => {
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances();
+
+      // Should only fetch once for 2022-07-12 (using end-of-day block 155, not creation block 152)
+      const calls = mockProvider.getBalance.mock.calls;
+      const callsForDate = calls.filter(
+        (call) => call[0] === "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      );
+      const blocksForDate = callsForDate.map((call) => call[1]);
+
+      expect(
+        blocksForDate.filter((block) => block === 155 || block === 152),
+      ).toHaveLength(1);
+      expect(blocksForDate).toContain(155); // Should use end-of-day block
+      expect(blocksForDate).not.toContain(152); // Should not use creation block
+    });
+
+    it("processes creation blocks in chronological order", async () => {
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          // Distributor created on 2023-03-16
+          "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 3163115,
+            date: "2023-03-16",
+            tx_hash:
+              "0x9f0fa92f662f8a5b0cfa7623282fadf6088b5e819901b85d4fce45b060941669",
+            method: "0xfcdde2b4",
+            owner: "0xD0749b3e537Ed52DE4e6a3Ae1eB6fc26059d0895",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce",
+          },
+          // Distributor created on 2022-08-10 (date not in block numbers)
+          "0xTestDistributor": {
+            type: DistributorType.L1_BASE_FEE,
+            block: 4000,
+            date: "2022-08-10",
+            tx_hash:
+              "0x0000000000000000000000000000000000000000000000000000000000000000",
+            method: "0x934be07d",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0xTestDistributor",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances();
+
+      // Get all calls and extract the blocks in order
+      const calls = mockProvider.getBalance.mock.calls;
+      const blocksCalled = calls.map((call) => call[1]);
+
+      // Find the position of the creation blocks
+      const creationBlock1Position = blocksCalled.indexOf(4000); // 2022-08-10
+      const creationBlock2Position = blocksCalled.indexOf(3163115); // 2023-03-16
+
+      // Creation block from 2022-08-10 should come before 2023-03-16
+      expect(creationBlock1Position).toBeGreaterThanOrEqual(0);
+      expect(creationBlock2Position).toBeGreaterThanOrEqual(0);
+      expect(creationBlock1Position).toBeLessThan(creationBlock2Position);
+    });
+  });
+
   describe("fetchBalances - filtering distributors", () => {
     let fetcher: BalanceFetcher;
     let mockDistributorsData: DistributorsData;

--- a/__tests__/units/balance-fetcher.test.ts
+++ b/__tests__/units/balance-fetcher.test.ts
@@ -428,7 +428,7 @@ describe("BalanceFetcher", () => {
       mockDistributorsData = {
         metadata: {
           chain_id: 42170,
-          arbowner_address: "0x0000000000000000000000000000000000000070",
+          arbowner_address: "0x0000000000000000000000000000000000000000000070",
           last_scanned_block: 1000,
         },
         distributors: {
@@ -480,6 +480,35 @@ describe("BalanceFetcher", () => {
       expect(creationBlock1Position).toBeGreaterThanOrEqual(0);
       expect(endOfDayBlock2Position).toBeGreaterThanOrEqual(0);
       expect(creationBlock1Position).toBeLessThan(endOfDayBlock2Position);
+    });
+
+    it("correctly sorts ISO date strings chronologically", () => {
+      // This test demonstrates that localeCompare works correctly for ISO date strings
+      const dates = [
+        "2023-03-16",
+        "2022-08-10",
+        "2022-07-12",
+        "2023-12-31",
+        "2022-01-01",
+      ];
+
+      // Sort using localeCompare (as in our implementation)
+      const sortedWithLocaleCompare = [...dates].sort((a, b) =>
+        a.localeCompare(b),
+      );
+
+      // Sort using regular string comparison
+      const sortedWithStringCompare = [...dates].sort();
+
+      // Both should produce the same result for ISO date strings
+      expect(sortedWithLocaleCompare).toEqual([
+        "2022-01-01",
+        "2022-07-12",
+        "2022-08-10",
+        "2023-03-16",
+        "2023-12-31",
+      ]);
+      expect(sortedWithStringCompare).toEqual(sortedWithLocaleCompare);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add distributor creation blocks to the balance fetch list to capture initial balance state
- Ensure creation time balance is fetched in addition to end-of-day balances
- Handle edge cases for distributors created mid-day vs those with future creation dates

## Implementation Details
Following TDD approach:
1. **RED**: Added failing tests for the new functionality
2. **GREEN**: Implemented minimal code to make tests pass
3. **REFACTOR**: Improved code clarity and maintainability

### Changes:
- Modified `BalanceFetcher.fetchBalances()` to include creation blocks when needed
- Creation block is added only when its date doesn't already have an end-of-day block
- All blocks are fetched in chronological order across multiple distributors
- Future distributors (with no applicable blocks) are skipped

## Test plan
- [x] Unit tests added for all new functionality
- [x] All existing tests still pass
- [x] TypeScript compilation successful
- [x] ESLint checks pass
- [x] Code properly formatted with Prettier

Closes #149