### PR TITLE
feat: Convert RPC balance responses to decimal strings

### DIFF
--- a/__tests__/units/balance-fetcher-decimal-conversion.test.ts
+++ b/__tests__/units/balance-fetcher-decimal-conversion.test.ts
@@ -1,0 +1,171 @@
+import { ethers } from "ethers";
+import { FileManager } from "../../src/file-manager";
+import { BalanceFetcher } from "../../src/balance-fetcher";
+import {
+  DistributorType,
+  DistributorsData,
+  BlockNumberData,
+  withRetry,
+} from "../../src/types";
+
+jest.mock("../../src/file-manager");
+jest.mock("../../src/types", () => ({
+  ...jest.requireActual("../../src/types"),
+  withRetry: jest.fn(),
+}));
+
+describe("BalanceFetcher - Decimal String Conversion", () => {
+  let mockFileManager: jest.Mocked<FileManager>;
+  let mockProvider: jest.Mocked<ethers.Provider>;
+  let fetcher: BalanceFetcher;
+  let mockWithRetry: jest.MockedFunction<typeof withRetry>;
+
+  beforeEach(() => {
+    mockFileManager = {
+      readDistributors: jest.fn(),
+      readBlockNumbers: jest.fn(),
+      readDistributorBalances: jest.fn(),
+      writeDistributorBalances: jest.fn(),
+    } as unknown as jest.Mocked<FileManager>;
+    mockProvider = {
+      getBalance: jest.fn(),
+    } as unknown as jest.Mocked<ethers.Provider>;
+    fetcher = new BalanceFetcher(mockFileManager, mockProvider);
+    mockWithRetry = withRetry as jest.MockedFunction<typeof withRetry>;
+
+    // Reset mock implementation
+    mockWithRetry.mockImplementation((operation) => operation());
+  });
+
+  describe("converting bigint balances to decimal strings", () => {
+    let mockDistributorsData: DistributorsData;
+    let mockBlockNumberData: BlockNumberData;
+
+    beforeEach(() => {
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      mockBlockNumberData = {
+        metadata: {
+          chain_id: 42170,
+        },
+        blocks: {
+          "2022-07-12": 155,
+          "2022-07-13": 189,
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+    });
+
+    it("returns decimal string instead of bigint for balance values", async () => {
+      // RPC returns bigint (simulating hex response 0x5d21dba000)
+      const hexBalance = BigInt("0x5d21dba000"); // 400000000000 in decimal
+      mockProvider.getBalance.mockResolvedValue(hexBalance);
+
+      const result = await fetcher.fetchBalances();
+
+      // Expect decimal string representation
+      expect(result).toEqual({
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+          "2022-07-12": "400000000000",
+          "2022-07-13": "400000000000",
+        },
+      });
+    });
+
+    it("converts zero balance correctly", async () => {
+      // RPC returns 0 as bigint
+      mockProvider.getBalance.mockResolvedValue(BigInt(0));
+
+      const result = await fetcher.fetchBalances();
+
+      // Expect "0" not empty string
+      expect(result).toEqual({
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+          "2022-07-12": "0",
+          "2022-07-13": "0",
+        },
+      });
+    });
+
+    it("handles very large balance values without scientific notation", async () => {
+      // Test with a very large balance (1 million ETH in wei)
+      const largeBalance = BigInt("0xd3c21bcecceda1000000"); // 1000000 * 10^18 wei
+      mockProvider.getBalance.mockResolvedValue(largeBalance);
+
+      const result = await fetcher.fetchBalances();
+
+      // Should be decimal string without scientific notation
+      expect(result).toEqual({
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+          "2022-07-12": "1000000000000000000000000",
+          "2022-07-13": "1000000000000000000000000",
+        },
+      });
+
+      // Verify no scientific notation
+      const addressBalances =
+        result!["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(addressBalances).toBeDefined();
+      expect(addressBalances!["2022-07-12"]).not.toContain("e");
+      expect(addressBalances!["2022-07-12"]).not.toContain("E");
+    });
+
+    it("maintains precision for all balance values", async () => {
+      // Test with a specific value from test data
+      const testBalance = BigInt("11840998262570272"); // From actual test data
+      mockProvider.getBalance.mockResolvedValue(testBalance);
+
+      const result = await fetcher.fetchBalances();
+
+      expect(result).toEqual({
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+          "2022-07-12": "11840998262570272",
+          "2022-07-13": "11840998262570272",
+        },
+      });
+    });
+
+    it("converts multiple different balances correctly", async () => {
+      const balances = {
+        155: BigInt("0x5d21dba000"), // 400000000000
+        189: BigInt("0x402dcd2fc8000"), // 1131212312000000
+      };
+
+      mockProvider.getBalance.mockImplementation(async (_address, block) => {
+        return balances[block as keyof typeof balances] || BigInt(0);
+      });
+
+      const result = await fetcher.fetchBalances();
+
+      expect(result).toEqual({
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+          "2022-07-12": "400000000000",
+          "2022-07-13": "1131212312000000",
+        },
+      });
+    });
+  });
+});

--- a/__tests__/units/balance-fetcher-decimal-conversion.test.ts
+++ b/__tests__/units/balance-fetcher-decimal-conversion.test.ts
@@ -151,7 +151,7 @@ describe("BalanceFetcher - Decimal String Conversion", () => {
     it("converts multiple different balances correctly", async () => {
       const balances = {
         155: BigInt("0x5d21dba000"), // 400000000000
-        189: BigInt("0x402dcd2fc8000"), // 1131212312000000
+        189: BigInt("0x402dcd2fc8000"), // 1129047362666496
       };
 
       mockProvider.getBalance.mockImplementation(async (_address, block) => {
@@ -163,7 +163,7 @@ describe("BalanceFetcher - Decimal String Conversion", () => {
       expect(result).toEqual({
         "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
           "2022-07-12": "400000000000",
-          "2022-07-13": "1131212312000000",
+          "2022-07-13": "1129047362666496",
         },
       });
     });

--- a/__tests__/units/balance-fetcher-rpc.test.ts
+++ b/__tests__/units/balance-fetcher-rpc.test.ts
@@ -128,7 +128,7 @@ describe("BalanceFetcher - RPC Balance Fetching", () => {
     });
   });
 
-  describe("storing bigint balance responses", () => {
+  describe("storing decimal string balance responses", () => {
     let mockDistributorsData: DistributorsData;
     let mockBlockNumberData: BlockNumberData;
 
@@ -170,7 +170,7 @@ describe("BalanceFetcher - RPC Balance Fetching", () => {
       mockFileManager.readDistributorBalances.mockReturnValue(undefined);
     });
 
-    it("returns collected bigint balances", async () => {
+    it("returns collected decimal string balances", async () => {
       // Set up different balances for different dates
       const balances = {
         "2022-07-12": BigInt("0x3635c9adc5dea00000"), // 1000 ETH in hex
@@ -185,11 +185,11 @@ describe("BalanceFetcher - RPC Balance Fetching", () => {
 
       const result = await fetcher.fetchBalances();
 
-      // Verify the returned structure contains bigint values
+      // Verify the returned structure contains decimal string values
       expect(result).toEqual({
         "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
-          "2022-07-12": BigInt("0x3635c9adc5dea00000"),
-          "2022-07-13": BigInt("0x6c6b935b8bbd400000"),
+          "2022-07-12": "1000000000000000000000",
+          "2022-07-13": "2000000000000000000000",
         },
       });
     });
@@ -225,12 +225,12 @@ describe("BalanceFetcher - RPC Balance Fetching", () => {
 
       expect(result).toEqual({
         "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
-          "2022-07-12": BigInt("0x3635c9adc5dea00000"),
-          "2022-07-13": BigInt("0x3635c9adc5dea00000"),
+          "2022-07-12": "1000000000000000000000",
+          "2022-07-13": "1000000000000000000000",
         },
         "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce": {
-          "2022-07-12": BigInt("0x1bc16d674ec80000"),
-          "2022-07-13": BigInt("0x1bc16d674ec80000"),
+          "2022-07-12": "2000000000000000000",
+          "2022-07-13": "2000000000000000000",
         },
       });
     });

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -24,12 +24,12 @@ export class BalanceFetcher {
    * Uses incremental processing to only fetch balances for dates that haven't been fetched yet.
    *
    * @param distributorAddress - If provided, only fetch balances for this specific distributor
-   * @returns Promise that resolves with collected bigint balances by distributor and date
+   * @returns Promise that resolves with collected decimal string balances by distributor and date
    * @throws Error on any failure
    */
   async fetchBalances(
     distributorAddress?: string,
-  ): Promise<Record<string, Record<string, bigint>> | undefined> {
+  ): Promise<Record<string, Record<string, string>> | undefined> {
     const distributorsData = this.fileManager.readDistributors();
 
     // Early return if no distributors data
@@ -115,7 +115,7 @@ export class BalanceFetcher {
     }
 
     // Collect balances by distributor and date
-    const collectedBalances: Record<string, Record<string, bigint>> = {};
+    const collectedBalances: Record<string, Record<string, string>> = {};
 
     // Fetch balances in chronological order
     for (const { address, date, block } of allFetches) {
@@ -127,11 +127,11 @@ export class BalanceFetcher {
         },
       );
 
-      // Store balance as bigint
+      // Store balance as decimal string
       if (!collectedBalances[address]) {
         collectedBalances[address] = {};
       }
-      collectedBalances[address][date] = balance;
+      collectedBalances[address][date] = balance.toString();
     }
 
     return collectedBalances;


### PR DESCRIPTION
## Summary
- Converts bigint balance values from RPC responses to decimal strings
- Ensures compatibility with BalanceData interface which expects string type for balance_wei
- Prevents precision loss by using native bigint.toString() method

## Changes
- Updated `BalanceFetcher.fetchBalances()` to return decimal strings instead of bigints
- Added comprehensive tests for decimal string conversion including edge cases
- Updated existing tests to expect decimal strings

## Test Plan
- [x] All existing tests pass
- [x] New tests cover:
  - Basic decimal string conversion
  - Zero balance handling ("0" not empty string)
  - Very large numbers without scientific notation
  - Precision preservation for all values
  - Multiple different balance conversions

Fixes #152