### PR TITLE
feat: merge and store balance data using FileManager

### DIFF
--- a/__tests__/units/balance-fetcher-decimal-conversion.test.ts
+++ b/__tests__/units/balance-fetcher-decimal-conversion.test.ts
@@ -29,6 +29,9 @@ describe("BalanceFetcher - Decimal String Conversion", () => {
     } as unknown as jest.Mocked<FileManager>;
     mockProvider = {
       getBalance: jest.fn(),
+      getNetwork: jest
+        .fn()
+        .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
     } as unknown as jest.Mocked<ethers.Provider>;
     fetcher = new BalanceFetcher(mockFileManager, mockProvider);
     mockWithRetry = withRetry as jest.MockedFunction<typeof withRetry>;

--- a/__tests__/units/balance-fetcher-incremental.test.ts
+++ b/__tests__/units/balance-fetcher-incremental.test.ts
@@ -24,6 +24,9 @@ describe("BalanceFetcher - Incremental Processing", () => {
     } as unknown as jest.Mocked<FileManager>;
     mockProvider = {
       getBalance: jest.fn(),
+      getNetwork: jest
+        .fn()
+        .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
     } as unknown as jest.Mocked<ethers.Provider>;
     fetcher = new BalanceFetcher(mockFileManager, mockProvider);
   });

--- a/__tests__/units/balance-fetcher-persistence.test.ts
+++ b/__tests__/units/balance-fetcher-persistence.test.ts
@@ -1,0 +1,288 @@
+import { ethers } from "ethers";
+import { FileManager } from "../../src/file-manager";
+import { BalanceFetcher } from "../../src/balance-fetcher";
+import {
+  DistributorType,
+  DistributorsData,
+  BlockNumberData,
+} from "../../src/types";
+
+jest.mock("../../src/file-manager");
+
+describe("BalanceFetcher - persistence", () => {
+  let mockFileManager: jest.Mocked<FileManager>;
+  let mockProvider: jest.Mocked<ethers.Provider>;
+  let fetcher: BalanceFetcher;
+
+  const mockDistributorsData: DistributorsData = {
+    metadata: {
+      chain_id: 42170,
+      arbowner_address: "0x0000000000000000000000000000000000000070",
+      last_scanned_block: 1000,
+    },
+    distributors: {
+      "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+        type: DistributorType.L2_SURPLUS_FEE,
+        block: 152,
+        date: "2022-07-12",
+        tx_hash:
+          "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+        method: "0xfcdde2b4",
+        owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+        event_data: "0x...",
+        is_reward_distributor: true,
+        distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      },
+    },
+  };
+
+  const mockBlockNumbersData: BlockNumberData = {
+    metadata: {
+      chain_id: 42170,
+    },
+    blocks: {
+      "2022-07-12": 152,
+      "2022-07-13": 100000,
+    },
+  };
+
+  beforeEach(() => {
+    mockFileManager = {
+      readDistributors: jest.fn(),
+      readBlockNumbers: jest.fn(),
+      readDistributorBalances: jest.fn(),
+      writeDistributorBalances: jest.fn(),
+    } as unknown as jest.Mocked<FileManager>;
+
+    mockProvider = {
+      getBalance: jest.fn(),
+    } as unknown as jest.Mocked<ethers.Provider>;
+
+    fetcher = new BalanceFetcher(mockFileManager, mockProvider);
+  });
+
+  describe("Cycle 1: Basic Storage of Fetched Balances", () => {
+    it("persists fetched balances using FileManager.writeDistributorBalances", async () => {
+      // Arrange
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined); // No existing data
+
+      const mockBalance = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance.mockResolvedValue(mockBalance);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        expect.objectContaining({
+          balances: expect.any(Object),
+        }),
+      );
+    });
+  });
+
+  describe("Cycle 2: Metadata Creation", () => {
+    it("includes correct metadata with chain_id and reward_distributor address", async () => {
+      // Arrange
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+
+      const mockBalance = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance.mockResolvedValue(mockBalance);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        {
+          metadata: {
+            chain_id: 42170,
+            reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          balances: expect.any(Object),
+        },
+      );
+    });
+  });
+
+  describe("Cycle 3: Incremental Merge", () => {
+    it("merges new balances with existing balance data", async () => {
+      // Arrange
+      const existingBalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000000",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(
+        existingBalanceData,
+      );
+
+      const mockBalance = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance.mockResolvedValue(mockBalance);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        {
+          metadata: {
+            chain_id: 42170,
+            reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          balances: {
+            "2022-07-12": {
+              block_number: 152,
+              balance_wei: "1000000000000000000000",
+            },
+            "2022-07-13": {
+              block_number: 100000,
+              balance_wei: "1500000000000000000000",
+            },
+          },
+        },
+      );
+    });
+  });
+
+  describe("Cycle 4: Multiple Distributors", () => {
+    it("saves balance data for all processed distributors", async () => {
+      // Arrange
+      const multipleDistributorsData: DistributorsData = {
+        ...mockDistributorsData,
+        distributors: {
+          ...mockDistributorsData.distributors,
+          "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce": {
+            type: DistributorType.L2_BASE_FEE,
+            block: 200,
+            date: "2022-07-12",
+            tx_hash:
+              "0x1234567890123456789012345678901234567890123456789012345678901234",
+            method: "0x57f585db",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(
+        multipleDistributorsData,
+      );
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+
+      const mockBalance1 = ethers.toBigInt("1500000000000000000000");
+      const mockBalance2 = ethers.toBigInt("2500000000000000000000");
+      mockProvider.getBalance
+        .mockResolvedValueOnce(mockBalance1)
+        .mockResolvedValueOnce(mockBalance1)
+        .mockResolvedValueOnce(mockBalance2)
+        .mockResolvedValueOnce(mockBalance2);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledTimes(2);
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        expect.any(Object),
+      );
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("Cycle 5: Edge Cases", () => {
+    it("does not call writeDistributorBalances when no new balances are fetched", async () => {
+      // Arrange
+      const completeBalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000000",
+          },
+          "2022-07-13": {
+            block_number: 100000,
+            balance_wei: "1500000000000000000000",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(
+        completeBalanceData,
+      );
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockProvider.getBalance).not.toHaveBeenCalled();
+      expect(mockFileManager.writeDistributorBalances).not.toHaveBeenCalled();
+    });
+
+    it("saves balance data with correct structure for dates and block numbers", async () => {
+      // Arrange
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+
+      const mockBalance1 = ethers.toBigInt("1000000000000000000000");
+      const mockBalance2 = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance
+        .mockResolvedValueOnce(mockBalance1)
+        .mockResolvedValueOnce(mockBalance2);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        {
+          metadata: {
+            chain_id: 42170,
+            reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          balances: {
+            "2022-07-12": {
+              block_number: 152,
+              balance_wei: "1000000000000000000000",
+            },
+            "2022-07-13": {
+              block_number: 100000,
+              balance_wei: "1500000000000000000000",
+            },
+          },
+        },
+      );
+    });
+  });
+});

--- a/__tests__/units/balance-fetcher-persistence.test.ts
+++ b/__tests__/units/balance-fetcher-persistence.test.ts
@@ -56,6 +56,9 @@ describe("BalanceFetcher - persistence", () => {
 
     mockProvider = {
       getBalance: jest.fn(),
+      getNetwork: jest
+        .fn()
+        .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
     } as unknown as jest.Mocked<ethers.Provider>;
 
     fetcher = new BalanceFetcher(mockFileManager, mockProvider);
@@ -282,6 +285,74 @@ describe("BalanceFetcher - persistence", () => {
             },
           },
         },
+      );
+    });
+
+    it("gets chain ID from provider when creating new balance data", async () => {
+      // Arrange
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+
+      const mockBalance = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance.mockResolvedValue(mockBalance);
+      mockProvider.getNetwork.mockResolvedValue({
+        chainId: 1234n,
+      } as unknown as ethers.Network);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockProvider.getNetwork).toHaveBeenCalled();
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            chain_id: 1234,
+          }),
+        }),
+      );
+    });
+
+    it("preserves existing chain ID when balance data already exists", async () => {
+      // Arrange
+      const existingBalanceData = {
+        metadata: {
+          chain_id: 9999,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000000",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readDistributorBalances.mockReturnValue(
+        existingBalanceData,
+      );
+
+      const mockBalance = ethers.toBigInt("1500000000000000000000");
+      mockProvider.getBalance.mockResolvedValue(mockBalance);
+      mockProvider.getNetwork.mockResolvedValue({
+        chainId: 42170n,
+      } as unknown as ethers.Network);
+
+      // Act
+      await fetcher.fetchBalances();
+
+      // Assert
+      expect(mockFileManager.writeDistributorBalances).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            chain_id: 9999, // Should preserve existing chain ID
+          }),
+        }),
       );
     });
   });

--- a/__tests__/units/balance-fetcher-rpc.test.ts
+++ b/__tests__/units/balance-fetcher-rpc.test.ts
@@ -29,6 +29,9 @@ describe("BalanceFetcher - RPC Balance Fetching", () => {
     } as unknown as jest.Mocked<FileManager>;
     mockProvider = {
       getBalance: jest.fn(),
+      getNetwork: jest
+        .fn()
+        .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
     } as unknown as jest.Mocked<ethers.Provider>;
     fetcher = new BalanceFetcher(mockFileManager, mockProvider);
     mockWithRetry = withRetry as jest.MockedFunction<typeof withRetry>;

--- a/__tests__/units/balance-fetcher.test.ts
+++ b/__tests__/units/balance-fetcher.test.ts
@@ -17,7 +17,11 @@ describe("BalanceFetcher", () => {
     mockFileManager = {
       readDistributors: jest.fn(),
     } as unknown as jest.Mocked<FileManager>;
-    mockProvider = {} as jest.Mocked<ethers.Provider>;
+    mockProvider = {
+      getNetwork: jest
+        .fn()
+        .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
+    } as unknown as jest.Mocked<ethers.Provider>;
   });
 
   describe("constructor", () => {
@@ -71,7 +75,11 @@ describe("BalanceFetcher", () => {
         writeDistributorBalances: jest.fn(),
         readBlockNumbers: jest.fn(),
       } as unknown as jest.Mocked<FileManager>;
-      mockProvider = {} as jest.Mocked<ethers.Provider>;
+      mockProvider = {
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
+      } as unknown as jest.Mocked<ethers.Provider>;
       fetcher = new BalanceFetcher(mockFileManager, mockProvider);
     });
 
@@ -147,7 +155,11 @@ describe("BalanceFetcher", () => {
         readDistributors: jest.fn(),
         readBlockNumbers: jest.fn(),
       } as unknown as jest.Mocked<FileManager>;
-      mockProvider = {} as jest.Mocked<ethers.Provider>;
+      mockProvider = {
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
+      } as unknown as jest.Mocked<ethers.Provider>;
       fetcher = new BalanceFetcher(mockFileManager, mockProvider);
 
       mockDistributorsData = {
@@ -196,6 +208,9 @@ describe("BalanceFetcher", () => {
       } as unknown as jest.Mocked<FileManager>;
       mockProvider = {
         getBalance: jest.fn(),
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
       } as unknown as jest.Mocked<ethers.Provider>;
       fetcher = new BalanceFetcher(mockFileManager, mockProvider);
 
@@ -322,6 +337,9 @@ describe("BalanceFetcher", () => {
       } as unknown as jest.Mocked<FileManager>;
       mockProvider = {
         getBalance: jest.fn(),
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
       } as unknown as jest.Mocked<ethers.Provider>;
       fetcher = new BalanceFetcher(mockFileManager, mockProvider);
 
@@ -523,7 +541,11 @@ describe("BalanceFetcher", () => {
         writeDistributorBalances: jest.fn(),
         readBlockNumbers: jest.fn(),
       } as unknown as jest.Mocked<FileManager>;
-      mockProvider = {} as jest.Mocked<ethers.Provider>;
+      mockProvider = {
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
+      } as unknown as jest.Mocked<ethers.Provider>;
       fetcher = new BalanceFetcher(mockFileManager, mockProvider);
 
       mockDistributorsData = {

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { FileManager } from "./file-manager";
-import { withRetry, BalanceData, CHAIN_IDS } from "./types";
+import { withRetry, BalanceData } from "./types";
 
 // Retry configuration for RPC calls
 const RPC_RETRY_CONFIG = {
@@ -28,10 +28,11 @@ export class BalanceFetcher {
     existingData: BalanceData | undefined,
     newBalances: Record<string, string>,
     allFetches: Array<{ address: string; date: string; block: number }>,
+    chainId: number,
   ): BalanceData {
     const balanceData: BalanceData = {
       metadata: {
-        chain_id: CHAIN_IDS.ARBITRUM_NOVA,
+        chain_id: existingData?.metadata.chain_id || chainId,
         reward_distributor: address,
       },
       balances: {
@@ -177,6 +178,10 @@ export class BalanceFetcher {
       collectedBalances[address][date] = balance.toString();
     }
 
+    // Get chain ID from provider for new balance data
+    const network = await this.provider.getNetwork();
+    const chainId = Number(network.chainId);
+
     // Save balance data for each distributor
     for (const [address, newBalances] of Object.entries(collectedBalances)) {
       const existingData = existingBalancesByDistributor[address];
@@ -185,6 +190,7 @@ export class BalanceFetcher {
         existingData,
         newBalances,
         allFetches,
+        chainId,
       );
       this.fileManager.writeDistributorBalances(address, balanceData);
     }

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -20,6 +20,42 @@ export class BalanceFetcher {
   ) {}
 
   /**
+   * Creates balance data structure for a distributor with metadata and balances.
+   * @private
+   */
+  private createBalanceData(
+    address: string,
+    existingData: BalanceData | undefined,
+    newBalances: Record<string, string>,
+    allFetches: Array<{ address: string; date: string; block: number }>,
+  ): BalanceData {
+    const balanceData: BalanceData = {
+      metadata: {
+        chain_id: CHAIN_IDS.ARBITRUM_NOVA,
+        reward_distributor: address,
+      },
+      balances: {
+        // Merge existing balances (if any)
+        ...(existingData?.balances || {}),
+      },
+    };
+
+    // Add new balances with block numbers
+    for (const [date, balanceWei] of Object.entries(newBalances)) {
+      const blockNumber = allFetches.find(
+        (f) => f.address === address && f.date === date,
+      )!.block;
+
+      balanceData.balances[date] = {
+        block_number: blockNumber,
+        balance_wei: balanceWei,
+      };
+    }
+
+    return balanceData;
+  }
+
+  /**
    * Fetches missing balances for all distributors or a specific distributor.
    * Uses incremental processing to only fetch balances for dates that haven't been fetched yet.
    *
@@ -144,32 +180,12 @@ export class BalanceFetcher {
     // Save balance data for each distributor
     for (const [address, newBalances] of Object.entries(collectedBalances)) {
       const existingData = existingBalancesByDistributor[address];
-
-      // Create balance data structure
-      const balanceData: BalanceData = {
-        metadata: {
-          chain_id: CHAIN_IDS.ARBITRUM_NOVA,
-          reward_distributor: address,
-        },
-        balances: {
-          // Merge existing balances (if any) with new balances
-          ...(existingData?.balances || {}),
-        },
-      };
-
-      // Add new balances with block numbers
-      for (const [date, balanceWei] of Object.entries(newBalances)) {
-        const blockNumber = allFetches.find(
-          (f) => f.address === address && f.date === date,
-        )!.block;
-
-        balanceData.balances[date] = {
-          block_number: blockNumber,
-          balance_wei: balanceWei,
-        };
-      }
-
-      // Write balance data
+      const balanceData = this.createBalanceData(
+        address,
+        existingData,
+        newBalances,
+        allFetches,
+      );
       this.fileManager.writeDistributorBalances(address, balanceData);
     }
 

--- a/src/balance-fetcher.ts
+++ b/src/balance-fetcher.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { FileManager } from "./file-manager";
-import { withRetry } from "./types";
+import { withRetry, BalanceData, CHAIN_IDS } from "./types";
 
 // Retry configuration for RPC calls
 const RPC_RETRY_CONFIG = {
@@ -62,6 +62,12 @@ export class BalanceFetcher {
         }
       : distributorsData.distributors;
 
+    // Map to track existing balances per distributor for merging
+    const existingBalancesByDistributor: Record<
+      string,
+      BalanceData | undefined
+    > = {};
+
     // Collect all address/date/block combinations
     const allFetches: Array<{ address: string; date: string; block: number }> =
       [];
@@ -77,6 +83,7 @@ export class BalanceFetcher {
       // Load existing balance data for this distributor
       const existingBalances =
         this.fileManager.readDistributorBalances(address);
+      existingBalancesByDistributor[address] = existingBalances;
 
       // Get all block numbers from creation date onward
       const endOfDayBlocks = Object.entries(blockNumbersData.blocks).filter(
@@ -132,6 +139,38 @@ export class BalanceFetcher {
         collectedBalances[address] = {};
       }
       collectedBalances[address][date] = balance.toString();
+    }
+
+    // Save balance data for each distributor
+    for (const [address, newBalances] of Object.entries(collectedBalances)) {
+      const existingData = existingBalancesByDistributor[address];
+
+      // Create balance data structure
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: CHAIN_IDS.ARBITRUM_NOVA,
+          reward_distributor: address,
+        },
+        balances: {
+          // Merge existing balances (if any) with new balances
+          ...(existingData?.balances || {}),
+        },
+      };
+
+      // Add new balances with block numbers
+      for (const [date, balanceWei] of Object.entries(newBalances)) {
+        const blockNumber = allFetches.find(
+          (f) => f.address === address && f.date === date,
+        )!.block;
+
+        balanceData.balances[date] = {
+          block_number: blockNumber,
+          balance_wei: balanceWei,
+        };
+      }
+
+      // Write balance data
+      this.fileManager.writeDistributorBalances(address, balanceData);
     }
 
     return collectedBalances;


### PR DESCRIPTION
## Summary
- Implements balance data persistence after fetching using FileManager
- Merges newly fetched balances with existing data incrementally  
- Includes proper metadata (chain_id and reward_distributor address)

## Implementation Details
This PR implements issue #153 by modifying the `fetchBalances` method to save fetched balance data:

1. **Data Structure**: Creates proper `BalanceData` structure with metadata containing:
   - `chain_id`: 42170 (ARBITRUM_NOVA)
   - `reward_distributor`: The distributor's address

2. **Incremental Merge**: Loads existing balance data and merges with new balances before saving

3. **Atomic Writes**: Uses `FileManager.writeDistributorBalances()` for atomic file updates

4. **Multiple Distributors**: Processes and saves data for all fetched distributors

## Testing
Comprehensive unit tests added in `balance-fetcher-persistence.test.ts` covering:
- Basic storage functionality
- Metadata creation
- Incremental merge behavior  
- Multiple distributor handling
- Edge cases (no new data to fetch)

All tests pass ✅

## TDD Process
Followed strict TDD methodology:
1. **RED**: Wrote failing tests for all scenarios
2. **GREEN**: Implemented minimal code to pass tests
3. **REFACTOR**: Extracted `createBalanceData` helper method for clarity

Closes #153