### PR TITLE
feat: create RecipientRecievedScanner class with basic scan method

### DIFF
--- a/__tests__/units/recipient-recieved-scanner.test.ts
+++ b/__tests__/units/recipient-recieved-scanner.test.ts
@@ -1,0 +1,106 @@
+import { ethers } from "ethers";
+import { FileManager } from "../../src/file-manager";
+import { RecipientRecievedScanner } from "../../src/recipient-recieved-scanner";
+
+jest.mock("../../src/file-manager");
+
+describe("RecipientRecievedScanner", () => {
+  let mockFileManager: jest.Mocked<FileManager>;
+  let mockProvider: jest.Mocked<ethers.Provider>;
+
+  beforeEach(() => {
+    mockFileManager = {} as jest.Mocked<FileManager>;
+    mockProvider = {} as jest.Mocked<ethers.Provider>;
+  });
+
+  describe("constructor", () => {
+    it("can be instantiated with Provider and FileManager dependencies", () => {
+      const scanner = new RecipientRecievedScanner(
+        mockProvider,
+        mockFileManager,
+      );
+      expect(scanner).toBeDefined();
+      expect(scanner).toBeInstanceOf(RecipientRecievedScanner);
+    });
+
+    it("stores provider as readonly property", () => {
+      const scanner = new RecipientRecievedScanner(
+        mockProvider,
+        mockFileManager,
+      );
+      expect(scanner.provider).toBe(mockProvider);
+    });
+
+    it("stores fileManager as readonly property", () => {
+      const scanner = new RecipientRecievedScanner(
+        mockProvider,
+        mockFileManager,
+      );
+      expect(scanner.fileManager).toBe(mockFileManager);
+    });
+  });
+
+  describe("scan", () => {
+    let scanner: RecipientRecievedScanner;
+
+    beforeEach(() => {
+      scanner = new RecipientRecievedScanner(mockProvider, mockFileManager);
+    });
+
+    it("exists as a method on RecipientRecievedScanner instance", () => {
+      expect(scanner.scan).toBeDefined();
+      expect(typeof scanner.scan).toBe("function");
+    });
+
+    it("accepts optional distributorAddress parameter", () => {
+      expect(scanner.scan.length).toBeLessThanOrEqual(1);
+    });
+
+    it("returns a Promise", () => {
+      const result = scanner.scan();
+      expect(result).toBeInstanceOf(Promise);
+      result.catch(() => {}); // Prevent unhandled promise rejection
+    });
+
+    it("returns Promise<void>", async () => {
+      const result = await scanner.scan();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("scan - address validation", () => {
+    let scanner: RecipientRecievedScanner;
+
+    beforeEach(() => {
+      scanner = new RecipientRecievedScanner(mockProvider, mockFileManager);
+    });
+
+    it("accepts a valid Ethereum address without throwing", async () => {
+      const validAddress = "0x1234567890123456789012345678901234567890";
+      await expect(scanner.scan(validAddress)).resolves.not.toThrow();
+    });
+
+    it("throws error for invalid Ethereum address", async () => {
+      const invalidAddress = "not-an-address";
+      await expect(scanner.scan(invalidAddress)).rejects.toThrow(
+        "Invalid Ethereum address: not-an-address",
+      );
+    });
+
+    it("throws error for address with invalid checksum", async () => {
+      const invalidChecksumAddress =
+        "0x1234567890123456789012345678901234567890ABC";
+      await expect(scanner.scan(invalidChecksumAddress)).rejects.toThrow(
+        "Invalid Ethereum address: 0x1234567890123456789012345678901234567890ABC",
+      );
+    });
+
+    it("works without distributorAddress parameter", async () => {
+      await expect(scanner.scan()).resolves.not.toThrow();
+    });
+
+    it("works with undefined distributorAddress", async () => {
+      await expect(scanner.scan(undefined)).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/recipient-recieved-scanner.ts
+++ b/src/recipient-recieved-scanner.ts
@@ -1,12 +1,26 @@
 import { ethers } from "ethers";
 import { FileManager } from "./file-manager";
 
+/**
+ * Creates a new RecipientRecievedScanner instance with the specified dependencies.
+ *
+ * @param provider - Ethereum provider for RPC calls
+ * @param fileManager - File manager instance for data persistence
+ */
 export class RecipientRecievedScanner {
   constructor(
     public readonly provider: ethers.Provider,
     public readonly fileManager: FileManager,
   ) {}
 
+  /**
+   * Scans for RecipientRecieved events and updates outflow data.
+   * Currently implements only address validation. Full implementation pending issue #173 and #174.
+   *
+   * @param distributorAddress - Optional distributor address. If provided, scans only that distributor. If omitted, scans all distributors
+   * @returns Promise that resolves when scanning is complete
+   * @throws Error if invalid Ethereum address provided
+   */
   async scan(distributorAddress?: string): Promise<void> {
     if (
       distributorAddress !== undefined &&

--- a/src/recipient-recieved-scanner.ts
+++ b/src/recipient-recieved-scanner.ts
@@ -1,0 +1,18 @@
+import { ethers } from "ethers";
+import { FileManager } from "./file-manager";
+
+export class RecipientRecievedScanner {
+  constructor(
+    public readonly provider: ethers.Provider,
+    public readonly fileManager: FileManager,
+  ) {}
+
+  async scan(distributorAddress?: string): Promise<void> {
+    if (
+      distributorAddress !== undefined &&
+      !ethers.isAddress(distributorAddress)
+    ) {
+      throw new Error(`Invalid Ethereum address: ${distributorAddress}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented basic RecipientRecievedScanner class structure following TDD practices
- Added scan method with address validation
- Created comprehensive unit tests

## Changes
- Created `src/recipient-recieved-scanner.ts` with:
  - RecipientRecievedScanner class accepting ethers.Provider and FileManager in constructor
  - `scan(distributorAddress?: string): Promise<void>` method
  - Address validation using ethers.isAddress
  - Error thrown for invalid addresses
- Added unit tests covering all functionality

## Test Plan
- [x] All unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Code properly formatted with Prettier

## Related Issues
Resolves #175

## Notes
- This is the basic implementation with address validation only
- Full event scanning functionality blocked by #173 (test data) and #174 (FileManager methods)
- Followed TDD approach with clear RED-GREEN-REFACTOR cycles