### PR TITLE
fix: integration test timeouts

### DIFF
--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -295,6 +295,9 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Incremental Processing", () => {
     it("should not fetch any new balances when run twice", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
+
       // First run - fetch all balances
       const firstResult = await balanceFetcher.fetchBalances();
       expect(Object.keys(firstResult).length).toBeGreaterThan(0);
@@ -316,13 +319,14 @@ describe("BalanceFetcher - Integration Tests", () => {
       fileManager.writeBlockNumbers(limitedBlockNumbers);
       await balanceFetcher.fetchBalances();
 
-      // Add more dates
-      fileManager.writeBlockNumbers(testBlockNumbers as BlockNumberData);
+      // Add more dates using minimal test data
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
 
       // Second run should only fetch new dates
       const secondResult = await balanceFetcher.fetchBalances();
 
       // Should have fetched balances for dates after 2022-07-13
+      expect(Object.keys(secondResult).length).toBeGreaterThan(0);
       for (const balances of Object.values(secondResult)) {
         for (const date of Object.keys(balances)) {
           expect(date).not.toBe("2022-07-12");

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-// import * as fs from "fs/promises";
-// import * as path from "path";
+import * as fs from "fs/promises";
+import * as path from "path";
 import { ethers } from "ethers";
 import { BalanceFetcher } from "../../src/balance-fetcher";
 import { FileManager } from "../../src/file-manager";
 import {
   DistributorsData,
   BlockNumberData,
-  // BalanceData,
+  BalanceData,
   DistributorType,
   DISTRIBUTOR_METHODS,
 } from "../../src/types";
@@ -63,22 +63,20 @@ const TEST_DISTRIBUTORS: Record<
 };
 
 // Helper to load expected balance data
-// Note: This function loads expected balance data for exact value verification
-// Currently not used as we're using minimal test data for performance
-// async function loadExpectedBalanceData(
-//   distributorAddress: string,
-// ): Promise<BalanceData> {
-//   // Convert to lowercase for directory path (test data directories use lowercase)
-//   const lowerCaseAddress = distributorAddress.toLowerCase();
-//   const balanceFilePath = path.join(
-//     __dirname,
-//     "../test-data/distributor-detector/balance_data",
-//     lowerCaseAddress,
-//     "balances.json",
-//   );
-//   const content = await fs.readFile(balanceFilePath, "utf-8");
-//   return JSON.parse(content);
-// }
+async function loadExpectedBalanceData(
+  distributorAddress: string,
+): Promise<BalanceData> {
+  // Convert to lowercase for directory path (test data directories use lowercase)
+  const lowerCaseAddress = distributorAddress.toLowerCase();
+  const balanceFilePath = path.join(
+    __dirname,
+    "../test-data/distributor-detector/balance_data",
+    lowerCaseAddress,
+    "balances.json",
+  );
+  const content = await fs.readFile(balanceFilePath, "utf-8");
+  return JSON.parse(content);
+}
 
 // Helper to create test distributors data
 function createTestDistributorsData(): DistributorsData {
@@ -256,40 +254,38 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Balance Value Verification", () => {
     it("should fetch correct balance values that match test data", async () => {
-      // This test needs specific block numbers to verify exact balance values
-      // For integration testing with minimal data, we'll just verify the structure
+      // Use minimal block numbers to prevent timeout
       fileManager.writeBlockNumbers(getMinimalBlockNumbers());
 
       // Act
       await balanceFetcher.fetchBalances();
 
-      // Assert - Verify structure and metadata
+      // Assert - Compare fetched balances with expected test data
+      const minimalDates = Object.keys(getMinimalBlockNumbers().blocks);
+
       for (const distributorAddress of Object.keys(TEST_DISTRIBUTORS)) {
         const fetchedData =
           fileManager.readDistributorBalances(distributorAddress);
+        const expectedData = await loadExpectedBalanceData(distributorAddress);
 
         expect(fetchedData).toBeDefined();
-        expect(fetchedData?.metadata.chain_id).toBe(ARBITRUM_NOVA_CHAIN_ID);
-        expect(fetchedData?.metadata.reward_distributor).toBe(
-          distributorAddress,
-        );
+        expect(fetchedData?.metadata).toEqual(expectedData.metadata);
 
-        // Verify we have balance entries for the minimal test dates
-        const minimalDates = Object.keys(getMinimalBlockNumbers().blocks);
+        // Verify balance values for dates that are in both minimal data and expected data
         for (const date of minimalDates) {
           const distributorInfo = TEST_DISTRIBUTORS[distributorAddress];
-          if (distributorInfo && date >= distributorInfo.createdAt) {
-            expect(fetchedData?.balances[date]).toBeDefined();
-            expect(fetchedData?.balances[date]?.balance_wei).toMatch(/^\d+$/);
-            expect(fetchedData?.balances[date]?.block_number).toBeGreaterThan(
-              0,
+          // Only check dates from distributor creation onward
+          if (
+            distributorInfo &&
+            date >= distributorInfo.createdAt &&
+            expectedData.balances[date]
+          ) {
+            expect(fetchedData?.balances[date]).toEqual(
+              expectedData.balances[date],
             );
           }
         }
       }
-
-      // Note: Exact balance value verification would require using the full test data
-      // with specific block numbers that match the expected test data
     });
   });
 
@@ -379,14 +375,18 @@ describe("BalanceFetcher - Integration Tests", () => {
       await balanceFetcher.fetchBalances();
 
       // Assert - Check distributor created on 2022-08-09 with creation block 684
-      const balanceData = fileManager.readDistributorBalances(
-        ethers.getAddress("0xdff90519a9DE6ad469D4f9839a9220C5D340B792"),
+      const distributorAddress = ethers.getAddress(
+        "0xdff90519a9DE6ad469D4f9839a9220C5D340B792",
       );
+      const fetchedData =
+        fileManager.readDistributorBalances(distributorAddress);
+      const expectedData = await loadExpectedBalanceData(distributorAddress);
 
-      // The test block numbers have 2022-08-09 at block 3584
-      // But the creation block 684 should also be included
-      expect(balanceData?.balances["2022-08-09"]).toBeDefined();
-      expect(balanceData?.balances["2022-08-09"]?.block_number).toBe(3584);
+      // Verify the balance for the creation date matches expected data
+      expect(fetchedData?.balances["2022-08-09"]).toBeDefined();
+      expect(fetchedData?.balances["2022-08-09"]).toEqual(
+        expectedData.balances["2022-08-09"],
+      );
     });
   });
 

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-import * as fs from "fs/promises";
-import * as path from "path";
+// import * as fs from "fs/promises";
+// import * as path from "path";
 import { ethers } from "ethers";
 import { BalanceFetcher } from "../../src/balance-fetcher";
 import { FileManager } from "../../src/file-manager";
 import {
   DistributorsData,
   BlockNumberData,
-  BalanceData,
+  // BalanceData,
   DistributorType,
   DISTRIBUTOR_METHODS,
 } from "../../src/types";
@@ -63,20 +63,22 @@ const TEST_DISTRIBUTORS: Record<
 };
 
 // Helper to load expected balance data
-async function loadExpectedBalanceData(
-  distributorAddress: string,
-): Promise<BalanceData> {
-  // Convert to lowercase for directory path (test data directories use lowercase)
-  const lowerCaseAddress = distributorAddress.toLowerCase();
-  const balanceFilePath = path.join(
-    __dirname,
-    "../test-data/distributor-detector/balance_data",
-    lowerCaseAddress,
-    "balances.json",
-  );
-  const content = await fs.readFile(balanceFilePath, "utf-8");
-  return JSON.parse(content);
-}
+// Note: This function loads expected balance data for exact value verification
+// Currently not used as we're using minimal test data for performance
+// async function loadExpectedBalanceData(
+//   distributorAddress: string,
+// ): Promise<BalanceData> {
+//   // Convert to lowercase for directory path (test data directories use lowercase)
+//   const lowerCaseAddress = distributorAddress.toLowerCase();
+//   const balanceFilePath = path.join(
+//     __dirname,
+//     "../test-data/distributor-detector/balance_data",
+//     lowerCaseAddress,
+//     "balances.json",
+//   );
+//   const content = await fs.readFile(balanceFilePath, "utf-8");
+//   return JSON.parse(content);
+// }
 
 // Helper to create test distributors data
 function createTestDistributorsData(): DistributorsData {
@@ -231,29 +233,40 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Balance Value Verification", () => {
     it("should fetch correct balance values that match test data", async () => {
+      // This test needs specific block numbers to verify exact balance values
+      // For integration testing with minimal data, we'll just verify the structure
+      fileManager.writeBlockNumbers(createMinimalBlockNumbers());
+
       // Act
       await balanceFetcher.fetchBalances();
 
-      // Assert - Compare fetched balances with expected test data
+      // Assert - Verify structure and metadata
       for (const distributorAddress of Object.keys(TEST_DISTRIBUTORS)) {
         const fetchedData =
           fileManager.readDistributorBalances(distributorAddress);
-        const expectedData = await loadExpectedBalanceData(distributorAddress);
 
         expect(fetchedData).toBeDefined();
-        expect(fetchedData?.metadata).toEqual(expectedData.metadata);
+        expect(fetchedData?.metadata.chain_id).toBe(ARBITRUM_NOVA_CHAIN_ID);
+        expect(fetchedData?.metadata.reward_distributor).toBe(
+          distributorAddress,
+        );
 
-        // Compare balance values for each date
-        for (const [date, expectedBalance] of Object.entries(
-          expectedData.balances,
-        )) {
-          // Only check dates from distributor creation onward
+        // Verify we have balance entries for the minimal test dates
+        const minimalDates = Object.keys(createMinimalBlockNumbers().blocks);
+        for (const date of minimalDates) {
           const distributorInfo = TEST_DISTRIBUTORS[distributorAddress];
           if (distributorInfo && date >= distributorInfo.createdAt) {
-            expect(fetchedData?.balances[date]).toEqual(expectedBalance);
+            expect(fetchedData?.balances[date]).toBeDefined();
+            expect(fetchedData?.balances[date]?.balance_wei).toMatch(/^\d+$/);
+            expect(fetchedData?.balances[date]?.block_number).toBeGreaterThan(
+              0,
+            );
           }
         }
       }
+
+      // Note: Exact balance value verification would require using the full test data
+      // with specific block numbers that match the expected test data
     });
   });
 

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -182,13 +182,13 @@ function getMinimalBlockNumbers(): BlockNumberData {
     "2022-07-12", // First distributor creation
     "2022-07-13", // Day after
     "2022-07-14", // Another day for first distributor
+    "2022-08-09", // Fifth distributor creation (edge case test)
     "2023-03-16", // Second distributor creation
     "2023-03-17", // Day after
     "2023-03-18", // Another day for distributors
     "2023-04-01", // Some time after all distributors created
     "2023-04-02", // Another day
     "2023-04-03", // Another day
-    "2023-04-04", // Final day
   ];
 
   const minimalBlocks: { [date: string]: number } = {};
@@ -338,6 +338,9 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Distributor Creation Date Filtering", () => {
     it("should only fetch balances from distributor creation date onward", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
+
       // Act
       await balanceFetcher.fetchBalances();
 
@@ -369,6 +372,9 @@ describe("BalanceFetcher - Integration Tests", () => {
     });
 
     it("should include creation block if no end-of-day block exists for creation date", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
+
       // Act
       await balanceFetcher.fetchBalances();
 
@@ -386,6 +392,9 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Single Distributor Filtering", () => {
     it("should only fetch balances for specified distributor", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
+
       const targetDistributor = ethers.getAddress(
         "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
       );
@@ -440,6 +449,9 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Return Value Verification", () => {
     it("should return collected balances as decimal strings", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
+
       // Act
       const result = await balanceFetcher.fetchBalances();
 

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -372,6 +372,16 @@ describe("BalanceFetcher - Integration Tests", () => {
       // The actual implementation uses withRetry which should handle transient failures
       // We'll just verify the balances are eventually fetched despite potential RPC issues
 
+      // Setup minimal test data - just 2 dates instead of 366
+      const minimalBlockNumbers: BlockNumberData = {
+        metadata: { chain_id: ARBITRUM_NOVA_CHAIN_ID },
+        blocks: {
+          "2023-03-15": 3120000,
+          "2023-03-16": 3163115,
+        },
+      };
+      fileManager.writeBlockNumbers(minimalBlockNumbers);
+
       // Act
       const result = await balanceFetcher.fetchBalances();
 

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -167,6 +167,18 @@ function createTestDistributorsData(): DistributorsData {
   return distributors;
 }
 
+// Helper function to create minimal block numbers for faster tests
+function createMinimalBlockNumbers(): BlockNumberData {
+  return {
+    metadata: { chain_id: ARBITRUM_NOVA_CHAIN_ID },
+    blocks: {
+      "2023-03-15": 3120000,
+      "2023-03-16": 3163115,
+      "2023-03-17": 3206230,
+    },
+  };
+}
+
 describe("BalanceFetcher - Integration Tests", () => {
   let testContext: TestContext;
   let balanceFetcher: BalanceFetcher;
@@ -193,6 +205,9 @@ describe("BalanceFetcher - Integration Tests", () => {
 
   describe("Basic Balance Fetching", () => {
     it("should fetch balances for all distributors and create balance files", async () => {
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(createMinimalBlockNumbers());
+
       // Act
       const result = await balanceFetcher.fetchBalances();
 

--- a/__tests__/integration/balance-fetcher-integration.test.ts
+++ b/__tests__/integration/balance-fetcher-integration.test.ts
@@ -169,15 +169,38 @@ function createTestDistributorsData(): DistributorsData {
   return distributors;
 }
 
-// Helper function to create minimal block numbers for faster tests
-function createMinimalBlockNumbers(): BlockNumberData {
+// Helper function to filter test block numbers to a subset for faster tests
+function getMinimalBlockNumbers(): BlockNumberData {
+  // Select strategic dates to cover all distributor creation periods
+  const allBlocks = (testBlockNumbers as BlockNumberData).blocks;
+
+  // Key dates based on distributor creation times:
+  // - 0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB: 2022-07-12
+  // - 0x3B68a689c929327224dBfCe31C1bf72Ffd2559Ce: 2023-03-16
+  // - Others are created around similar times
+  const strategicDates = [
+    "2022-07-12", // First distributor creation
+    "2022-07-13", // Day after
+    "2022-07-14", // Another day for first distributor
+    "2023-03-16", // Second distributor creation
+    "2023-03-17", // Day after
+    "2023-03-18", // Another day for distributors
+    "2023-04-01", // Some time after all distributors created
+    "2023-04-02", // Another day
+    "2023-04-03", // Another day
+    "2023-04-04", // Final day
+  ];
+
+  const minimalBlocks: { [date: string]: number } = {};
+  strategicDates.forEach((date) => {
+    if (allBlocks[date]) {
+      minimalBlocks[date] = allBlocks[date];
+    }
+  });
+
   return {
-    metadata: { chain_id: ARBITRUM_NOVA_CHAIN_ID },
-    blocks: {
-      "2023-03-15": 3120000,
-      "2023-03-16": 3163115,
-      "2023-03-17": 3206230,
-    },
+    metadata: (testBlockNumbers as BlockNumberData).metadata,
+    blocks: minimalBlocks,
   };
 }
 
@@ -208,7 +231,7 @@ describe("BalanceFetcher - Integration Tests", () => {
   describe("Basic Balance Fetching", () => {
     it("should fetch balances for all distributors and create balance files", async () => {
       // Use minimal test data to prevent timeout
-      fileManager.writeBlockNumbers(createMinimalBlockNumbers());
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
 
       // Act
       const result = await balanceFetcher.fetchBalances();
@@ -235,7 +258,7 @@ describe("BalanceFetcher - Integration Tests", () => {
     it("should fetch correct balance values that match test data", async () => {
       // This test needs specific block numbers to verify exact balance values
       // For integration testing with minimal data, we'll just verify the structure
-      fileManager.writeBlockNumbers(createMinimalBlockNumbers());
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
 
       // Act
       await balanceFetcher.fetchBalances();
@@ -252,7 +275,7 @@ describe("BalanceFetcher - Integration Tests", () => {
         );
 
         // Verify we have balance entries for the minimal test dates
-        const minimalDates = Object.keys(createMinimalBlockNumbers().blocks);
+        const minimalDates = Object.keys(getMinimalBlockNumbers().blocks);
         for (const date of minimalDates) {
           const distributorInfo = TEST_DISTRIBUTORS[distributorAddress];
           if (distributorInfo && date >= distributorInfo.createdAt) {
@@ -400,15 +423,8 @@ describe("BalanceFetcher - Integration Tests", () => {
       // The actual implementation uses withRetry which should handle transient failures
       // We'll just verify the balances are eventually fetched despite potential RPC issues
 
-      // Setup minimal test data - just 2 dates instead of 366
-      const minimalBlockNumbers: BlockNumberData = {
-        metadata: { chain_id: ARBITRUM_NOVA_CHAIN_ID },
-        blocks: {
-          "2023-03-15": 3120000,
-          "2023-03-16": 3163115,
-        },
-      };
-      fileManager.writeBlockNumbers(minimalBlockNumbers);
+      // Use minimal test data to prevent timeout
+      fileManager.writeBlockNumbers(getMinimalBlockNumbers());
 
       // Act
       const result = await balanceFetcher.fetchBalances();

--- a/__tests__/integration/distributor-detector-integration.test.ts
+++ b/__tests__/integration/distributor-detector-integration.test.ts
@@ -286,12 +286,12 @@ describe("DistributorDetector - Integration Tests", () => {
         testBlockNumbers as BlockNumberData,
       );
 
-      // Use date not in block numbers
-      const endDate = new Date("2025-01-01");
+      // Use date not in block numbers (test data ends at 2025-06-23)
+      const endDate = new Date("2026-01-01");
 
       await expect(
         distributorDetector.detectDistributors(endDate),
-      ).rejects.toThrow("Block number not found for date 2025-01-01");
+      ).rejects.toThrow("Block number not found for date 2026-01-01");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixing integration tests that are timing out due to excessive RPC calls
- Tests are making real network calls to Arbitrum Nova RPC
- no-issue: fixing failing tests

## Test plan
- [x] Fixed "should handle RPC failures with retry" test by reducing test data from 366 dates to 2 dates
- [ ] Fix remaining failing tests

## Progress
- Fixed 1/10 failing tests
- Reduced RPC calls from ~1,830 to ~10 in the fixed test
- Test now completes in under 1 second instead of timing out