### PR TITLE
feat: add distribution event processing to fee calculations

### DIFF
--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -876,5 +876,162 @@ describe("FeeCalculator - Integration Tests", () => {
       expect(day1.distributions_count).toBe(3); // 3 events
       expect(day1.total_wei).toBe("1600000000000000000"); // 1.6 ETH total (1 + 0.6)
     });
+
+    it("should handle mixed dates with and without distribution events", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      // Setup balance data for multiple days
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 1000,
+            balance_wei: "1000000000000000000", // 1 ETH
+          },
+          "2022-07-13": {
+            block_number: 2000,
+            balance_wei: "2000000000000000000", // 2 ETH
+          },
+          "2022-07-14": {
+            block_number: 3000,
+            balance_wei: "2500000000000000000", // 2.5 ETH
+          },
+          "2022-07-15": {
+            block_number: 4000,
+            balance_wei: "3000000000000000000", // 3 ETH
+          },
+        },
+      };
+
+      // Setup distribution events - some days have events, some don't
+      const eventsData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          last_scanned_block: 4000,
+        },
+        events: {
+          // Day 1 - two events
+          "0xaaaa000000000000000000000000000000000000000000000000000000000001:0":
+            {
+              blockNumber: 500,
+              transactionHash:
+                "0xaaaa000000000000000000000000000000000000000000000000000000000001",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "100000000000000000", // 0.1 ETH
+            },
+          "0xaaaa000000000000000000000000000000000000000000000000000000000002:0":
+            {
+              blockNumber: 800,
+              transactionHash:
+                "0xaaaa000000000000000000000000000000000000000000000000000000000002",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "150000000000000000", // 0.15 ETH
+            },
+          // Day 2 - no events
+          // Day 3 - one event
+          "0xcccc000000000000000000000000000000000000000000000000000000000001:0":
+            {
+              blockNumber: 2800,
+              transactionHash:
+                "0xcccc000000000000000000000000000000000000000000000000000000000001",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "300000000000000000", // 0.3 ETH
+            },
+          // Day 4 - no events
+        },
+      };
+
+      // Write test data
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData,
+      );
+      fileManager.writeRecipientRecievedEvents(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        eventsData,
+      );
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Read and verify the fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+
+      const distributorReport =
+        feeReport!.distributors["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(distributorReport).toHaveLength(4);
+
+      // Day 1: Balance change 1 ETH + distributions 0.25 ETH
+      const day1 = distributorReport![0]!;
+      expect(day1.date).toBe("2022-07-12");
+      expect(day1.balance_change_wei).toBe("1000000000000000000");
+      expect(day1.distributions_wei).toBe("250000000000000000"); // 0.1 + 0.15
+      expect(day1.distributions_count).toBe(2);
+      expect(day1.total_wei).toBe("1250000000000000000");
+
+      // Day 2: Balance change 1 ETH + no distributions
+      const day2 = distributorReport![1]!;
+      expect(day2.date).toBe("2022-07-13");
+      expect(day2.balance_change_wei).toBe("1000000000000000000");
+      expect(day2.distributions_wei).toBe("0");
+      expect(day2.distributions_count).toBe(0);
+      expect(day2.total_wei).toBe("1000000000000000000");
+
+      // Day 3: Balance change 0.5 ETH + distribution 0.3 ETH
+      const day3 = distributorReport![2]!;
+      expect(day3.date).toBe("2022-07-14");
+      expect(day3.balance_change_wei).toBe("500000000000000000");
+      expect(day3.distributions_wei).toBe("300000000000000000");
+      expect(day3.distributions_count).toBe(1);
+      expect(day3.total_wei).toBe("800000000000000000");
+
+      // Day 4: Balance change 0.5 ETH + no distributions
+      const day4 = distributorReport![3]!;
+      expect(day4.date).toBe("2022-07-15");
+      expect(day4.balance_change_wei).toBe("500000000000000000");
+      expect(day4.distributions_wei).toBe("0");
+      expect(day4.distributions_count).toBe(0);
+      expect(day4.total_wei).toBe("500000000000000000");
+    });
   });
 });

--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -654,5 +654,110 @@ describe("FeeCalculator - Integration Tests", () => {
         "2000000000000000000",
       );
     });
+
+    it("should include distribution events in fee calculations", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      // Setup balance data
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000", // 1 ETH
+          },
+          "2022-07-13": {
+            block_number: 1000,
+            balance_wei: "1500000000000000000", // 1.5 ETH
+          },
+        },
+      };
+
+      // Setup distribution events - one event on 2022-07-12
+      const eventsData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          last_scanned_block: 1000,
+        },
+        events: {
+          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef:0":
+            {
+              blockNumber: 150,
+              transactionHash:
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "200000000000000000", // 0.2 ETH distribution
+            },
+        },
+      };
+
+      // Write test data
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData,
+      );
+      fileManager.writeRecipientRecievedEvents(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        eventsData,
+      );
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Read and verify the fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+
+      const distributorReport =
+        feeReport!.distributors["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(distributorReport).toHaveLength(2);
+
+      // First day - should include distribution
+      const day1 = distributorReport![0]!;
+      expect(day1.date).toBe("2022-07-12");
+      expect(day1.balance_change_wei).toBe("1000000000000000000"); // 1 ETH balance change
+      expect(day1.distributions_wei).toBe("200000000000000000"); // 0.2 ETH distribution
+      expect(day1.distributions_count).toBe(1);
+      expect(day1.total_wei).toBe("1200000000000000000"); // 1.2 ETH total (1 + 0.2)
+
+      // Second day - no distributions
+      const day2 = distributorReport![1]!;
+      expect(day2.date).toBe("2022-07-13");
+      expect(day2.balance_change_wei).toBe("500000000000000000"); // 0.5 ETH balance change
+      expect(day2.distributions_wei).toBe("0");
+      expect(day2.distributions_count).toBe(0);
+      expect(day2.total_wei).toBe("500000000000000000"); // 0.5 ETH total
+    });
   });
 });

--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -759,5 +759,122 @@ describe("FeeCalculator - Integration Tests", () => {
       expect(day2.distributions_count).toBe(0);
       expect(day2.total_wei).toBe("500000000000000000"); // 0.5 ETH total
     });
+
+    it("should sum multiple distribution events on the same date", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      // Setup balance data
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000", // 1 ETH
+          },
+        },
+      };
+
+      // Setup multiple distribution events on the same date
+      const eventsData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          last_scanned_block: 200,
+        },
+        events: {
+          "0x1111111111111111111111111111111111111111111111111111111111111111:0":
+            {
+              blockNumber: 100,
+              transactionHash:
+                "0x1111111111111111111111111111111111111111111111111111111111111111",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "100000000000000000", // 0.1 ETH
+            },
+          "0x2222222222222222222222222222222222222222222222222222222222222222:0":
+            {
+              blockNumber: 120,
+              transactionHash:
+                "0x2222222222222222222222222222222222222222222222222222222222222222",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "200000000000000000", // 0.2 ETH
+            },
+          "0x3333333333333333333333333333333333333333333333333333333333333333:0":
+            {
+              blockNumber: 150,
+              transactionHash:
+                "0x3333333333333333333333333333333333333333333333333333333333333333",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              value: "300000000000000000", // 0.3 ETH
+            },
+        },
+      };
+
+      // Write test data
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData,
+      );
+      fileManager.writeRecipientRecievedEvents(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        eventsData,
+      );
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Read and verify the fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+
+      const distributorReport =
+        feeReport!.distributors["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(distributorReport).toHaveLength(1);
+
+      // Should sum all three events: 0.1 + 0.2 + 0.3 = 0.6 ETH
+      const day1 = distributorReport![0]!;
+      expect(day1.date).toBe("2022-07-12");
+      expect(day1.balance_change_wei).toBe("1000000000000000000"); // 1 ETH balance change
+      expect(day1.distributions_wei).toBe("600000000000000000"); // 0.6 ETH total distributions
+      expect(day1.distributions_count).toBe(3); // 3 events
+      expect(day1.total_wei).toBe("1600000000000000000"); // 1.6 ETH total (1 + 0.6)
+    });
   });
 });

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -11,9 +11,6 @@ type FeeReportEntry = {
   total_wei: string;
 };
 
-// Constants for fee calculation
-const NO_DISTRIBUTIONS_COUNT = 0;
-
 export class FeeCalculator {
   constructor(public readonly fileManager: FileManager) {}
 
@@ -143,7 +140,7 @@ export class FeeCalculator {
     if (!eventsData || !eventsData.events) {
       return {
         distributionsWei: BigInt(0),
-        distributionsCount: NO_DISTRIBUTIONS_COUNT,
+        distributionsCount: 0,
       };
     }
 

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -12,7 +12,6 @@ type FeeReportEntry = {
 };
 
 // Constants for fee calculation
-const NO_DISTRIBUTIONS = "0";
 const NO_DISTRIBUTIONS_COUNT = 0;
 
 export class FeeCalculator {
@@ -84,7 +83,6 @@ export class FeeCalculator {
       // Calculate distributions for this date
       const { distributionsWei, distributionsCount } =
         this.calculateDistributionsForDate(
-          date,
           previousEndBlock + 1, // Start from block after previous day
           balances[date]!.block_number, // End at this day's block
           eventsData,
@@ -109,47 +107,42 @@ export class FeeCalculator {
   private calculateBalanceChange(
     currentBalanceWei: string,
     previousBalanceWei: string,
-  ): string {
+  ): bigint {
     const currentBigInt = BigInt(currentBalanceWei);
     const previousBigInt = BigInt(previousBalanceWei);
-    const changeWei = currentBigInt - previousBigInt;
-
-    return changeWei.toString();
+    return currentBigInt - previousBigInt;
   }
 
   private createDailyEntry(
     date: string,
     balanceWei: string,
-    balanceChangeWei: string,
-    distributionsWei: string,
+    balanceChangeWei: bigint,
+    distributionsWei: bigint,
     distributionsCount: number,
   ): FeeReportEntry {
     // Calculate total_wei as sum of balance change and distributions
-    const balanceChangeBigInt = BigInt(balanceChangeWei);
-    const distributionsBigInt = BigInt(distributionsWei);
-    const totalWei = (balanceChangeBigInt + distributionsBigInt).toString();
+    const totalWei = balanceChangeWei + distributionsWei;
 
     return {
       date,
       start_balance_wei: balanceWei,
       end_balance_wei: balanceWei,
-      balance_change_wei: balanceChangeWei,
-      distributions_wei: distributionsWei,
+      balance_change_wei: balanceChangeWei.toString(),
+      distributions_wei: distributionsWei.toString(),
       distributions_count: distributionsCount,
-      total_wei: totalWei,
+      total_wei: totalWei.toString(),
     };
   }
 
   private calculateDistributionsForDate(
-    _date: string,
     startBlockNumber: number,
     endBlockNumber: number,
     eventsData: RecipientRecievedEventData | undefined,
-  ): { distributionsWei: string; distributionsCount: number } {
+  ): { distributionsWei: bigint; distributionsCount: number } {
     // If no events data, return zeros
     if (!eventsData || !eventsData.events) {
       return {
-        distributionsWei: NO_DISTRIBUTIONS,
+        distributionsWei: BigInt(0),
         distributionsCount: NO_DISTRIBUTIONS_COUNT,
       };
     }
@@ -170,7 +163,7 @@ export class FeeCalculator {
     }
 
     return {
-      distributionsWei: totalDistributions.toString(),
+      distributionsWei: totalDistributions,
       distributionsCount: count,
     };
   }

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -1,4 +1,4 @@
-import { FileManager, FeeReport } from "./types";
+import { FileManager, FeeReport, RecipientRecievedEventData } from "./types";
 
 // Type for individual fee report entries
 type FeeReportEntry = {
@@ -40,10 +40,16 @@ export class FeeCalculator {
     const sortedDates = Object.keys(balanceData.balances).sort();
     if (sortedDates.length === 0) return;
 
+    // Read distribution events for the first distributor
+    const eventsData = this.fileManager.readRecipientRecievedEvents(
+      firstDistributorAddress,
+    );
+
     // Process all dates to create daily entries
     const dailyEntries = this.createDailyEntries(
       sortedDates,
       balanceData.balances,
+      eventsData,
     );
 
     // Create and write fee report
@@ -62,6 +68,7 @@ export class FeeCalculator {
   private createDailyEntries(
     sortedDates: string[],
     balances: { [date: string]: { block_number: number; balance_wei: string } },
+    eventsData: RecipientRecievedEventData | undefined,
   ): FeeReportEntry[] {
     const dailyEntries: FeeReportEntry[] = [];
     let previousBalanceWei: string = "0"; // Start with 0 as previous balance
@@ -73,11 +80,21 @@ export class FeeCalculator {
         previousBalanceWei,
       );
 
+      // Calculate distributions for this date
+      const { distributionsWei, distributionsCount } =
+        this.calculateDistributionsForDate(
+          date,
+          balances[date]!.block_number,
+          eventsData,
+        );
+
       dailyEntries.push(
         this.createDailyEntry(
           date,
           currentBalance.balance_wei,
           balanceChangeWei,
+          distributionsWei,
+          distributionsCount,
         ),
       );
       previousBalanceWei = currentBalance.balance_wei;
@@ -101,15 +118,59 @@ export class FeeCalculator {
     date: string,
     balanceWei: string,
     balanceChangeWei: string,
+    distributionsWei: string,
+    distributionsCount: number,
   ): FeeReportEntry {
+    // Calculate total_wei as sum of balance change and distributions
+    const balanceChangeBigInt = BigInt(balanceChangeWei);
+    const distributionsBigInt = BigInt(distributionsWei);
+    const totalWei = (balanceChangeBigInt + distributionsBigInt).toString();
+
     return {
       date,
       start_balance_wei: balanceWei,
       end_balance_wei: balanceWei,
       balance_change_wei: balanceChangeWei,
-      distributions_wei: NO_DISTRIBUTIONS,
-      distributions_count: NO_DISTRIBUTIONS_COUNT,
-      total_wei: balanceChangeWei, // Since distributions are always 0 for now
+      distributions_wei: distributionsWei,
+      distributions_count: distributionsCount,
+      total_wei: totalWei,
+    };
+  }
+
+  private calculateDistributionsForDate(
+    date: string,
+    endBlockNumber: number,
+    eventsData: RecipientRecievedEventData | undefined,
+  ): { distributionsWei: string; distributionsCount: number } {
+    // If no events data, return zeros
+    if (!eventsData || !eventsData.events) {
+      return {
+        distributionsWei: NO_DISTRIBUTIONS,
+        distributionsCount: NO_DISTRIBUTIONS_COUNT,
+      };
+    }
+
+    // For now, we'll use a simple approach: check if event block number <= end block
+    // In a real implementation, we'd need access to block numbers data to determine the exact range
+    let totalDistributions = BigInt(0);
+    let count = 0;
+
+    for (const event of Object.values(eventsData.events)) {
+      // Check if event belongs to this date (block number <= end block for this date)
+      if (event.blockNumber <= endBlockNumber) {
+        // For the first date, include all events up to this block
+        // For subsequent dates, we'd need to track which events we've already counted
+        // For this minimal implementation, we'll just check the block number
+        if (event.blockNumber === 150 && date === "2022-07-12") {
+          totalDistributions += BigInt(event.value);
+          count++;
+        }
+      }
+    }
+
+    return {
+      distributionsWei: totalDistributions.toString(),
+      distributionsCount: count,
     };
   }
 }

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -72,6 +72,7 @@ export class FeeCalculator {
   ): FeeReportEntry[] {
     const dailyEntries: FeeReportEntry[] = [];
     let previousBalanceWei: string = "0"; // Start with 0 as previous balance
+    let previousEndBlock: number = 0; // Track previous day's end block
 
     for (const date of sortedDates) {
       const currentBalance = balances[date]!;
@@ -84,7 +85,8 @@ export class FeeCalculator {
       const { distributionsWei, distributionsCount } =
         this.calculateDistributionsForDate(
           date,
-          balances[date]!.block_number,
+          previousEndBlock + 1, // Start from block after previous day
+          balances[date]!.block_number, // End at this day's block
           eventsData,
         );
 
@@ -98,6 +100,7 @@ export class FeeCalculator {
         ),
       );
       previousBalanceWei = currentBalance.balance_wei;
+      previousEndBlock = balances[date]!.block_number;
     }
 
     return dailyEntries;
@@ -138,7 +141,8 @@ export class FeeCalculator {
   }
 
   private calculateDistributionsForDate(
-    date: string,
+    _date: string,
+    startBlockNumber: number,
     endBlockNumber: number,
     eventsData: RecipientRecievedEventData | undefined,
   ): { distributionsWei: string; distributionsCount: number } {
@@ -150,21 +154,18 @@ export class FeeCalculator {
       };
     }
 
-    // For now, we'll use a simple approach: check if event block number <= end block
-    // In a real implementation, we'd need access to block numbers data to determine the exact range
+    // Count events within the block range for this date
     let totalDistributions = BigInt(0);
     let count = 0;
 
     for (const event of Object.values(eventsData.events)) {
-      // Check if event belongs to this date (block number <= end block for this date)
-      if (event.blockNumber <= endBlockNumber) {
-        // For the first date, include all events up to this block
-        // For subsequent dates, we'd need to track which events we've already counted
-        // For this minimal implementation, we'll just check the block number
-        if (event.blockNumber === 150 && date === "2022-07-12") {
-          totalDistributions += BigInt(event.value);
-          count++;
-        }
+      // Check if event is within this date's block range
+      if (
+        event.blockNumber >= startBlockNumber &&
+        event.blockNumber <= endBlockNumber
+      ) {
+        totalDistributions += BigInt(event.value);
+        count++;
       }
     }
 


### PR DESCRIPTION
## Summary
- Extends FeeCalculator to include RecipientRecieved events in daily fee totals
- Implements formula: `total_wei = balance_change_wei + distributions_wei`
- Processes single distributor only (as per requirements)

## Changes
- Modified `FeeCalculator.calculateFees()` to read distribution events using FileManager
- Added date range filtering to sum events within each day's block range
- Includes distribution amount and count in fee report output
- Days without events have `distributions_wei = "0"` and `distributions_count = 0`

## Test Coverage
- Added test for single distribution event processing
- Added test for summing multiple events on same date
- Added comprehensive test for mixed dates with and without events
- All existing tests continue to pass

## Testing
All tests pass:
- 13 fee calculator integration tests
- No linting or type errors

Resolves #196