### PR TITLE
Feat: Add multiple distributor support to fee calculations

### DIFF
--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -1269,5 +1269,160 @@ describe("FeeCalculator - Integration Tests", () => {
       expect(d3Day1.distributions_count).toBe(0);
       expect(d3Day1.total_wei).toBe("3000000000000000000");
     });
+
+    it("should handle multiple distributors with mixed data availability", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          // Distributor with balance and events
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          // Distributor with no balance data
+          "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9": {
+            type: DistributorType.L1_SURPLUS_FEE,
+            block: 200,
+            date: "2022-07-13",
+            tx_hash:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            method: "0x934be07d",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 2",
+            is_reward_distributor: true,
+            distributor_address: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+          },
+          // Distributor with empty balance data
+          "0x509386DbF5C0BE6fd68Df97A05fdB375136c32De": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 300,
+            date: "2022-07-14",
+            tx_hash:
+              "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 3",
+            is_reward_distributor: true,
+            distributor_address: "0x509386DbF5C0BE6fd68Df97A05fdB375136c32De",
+          },
+        },
+      };
+
+      // Setup balance data only for first distributor
+      const balanceData1: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 1000,
+            balance_wei: "1000000000000000000", // 1 ETH
+          },
+        },
+      };
+
+      // Empty balance data for third distributor
+      const emptyBalanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x509386DbF5C0BE6fd68Df97A05fdB375136c32De",
+        },
+        balances: {},
+      };
+
+      // Write test data
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData1,
+      );
+      // Second distributor has no balance data file at all
+      fileManager.writeDistributorBalances(
+        "0x509386DbF5C0BE6fd68Df97A05fdB375136c32De",
+        emptyBalanceData,
+      );
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Read and verify the fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+
+      // Only first distributor should be in report
+      expect(Object.keys(feeReport!.distributors)).toHaveLength(1);
+      expect(feeReport!.distributors).toHaveProperty(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      );
+      expect(feeReport!.distributors).not.toHaveProperty(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+      );
+      expect(feeReport!.distributors).not.toHaveProperty(
+        "0x509386DbF5C0BE6fd68Df97A05fdB375136c32De",
+      );
+    });
+
+    it("should handle when no distributors have valid data", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9": {
+            type: DistributorType.L1_SURPLUS_FEE,
+            block: 200,
+            date: "2022-07-13",
+            tx_hash:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            method: "0x934be07d",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 2",
+            is_reward_distributor: true,
+            distributor_address: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+          },
+        },
+      };
+
+      // Write only distributors data, no balance data
+      fileManager.writeDistributors(distributorsData);
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Should not write any fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeUndefined();
+    });
   });
 });

--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -1033,5 +1033,241 @@ describe("FeeCalculator - Integration Tests", () => {
       expect(day4.distributions_count).toBe(0);
       expect(day4.total_wei).toBe("500000000000000000");
     });
+
+    it("should process all distributors, not just the first one", () => {
+      const { fileManager } = testContext;
+
+      // Setup distributors data with multiple distributors
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9": {
+            type: DistributorType.L1_SURPLUS_FEE,
+            block: 200,
+            date: "2022-07-13",
+            tx_hash:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            method: "0x934be07d",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 2",
+            is_reward_distributor: true,
+            distributor_address: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+          },
+          "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 300,
+            date: "2022-07-14",
+            tx_hash:
+              "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 3",
+            is_reward_distributor: true,
+            distributor_address: "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD",
+          },
+        },
+      };
+
+      // Setup balance data for first distributor
+      const balanceData1: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 1000,
+            balance_wei: "1000000000000000000", // 1 ETH
+          },
+          "2022-07-13": {
+            block_number: 2000,
+            balance_wei: "1500000000000000000", // 1.5 ETH
+          },
+        },
+      };
+
+      // Setup balance data for second distributor
+      const balanceData2: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+        },
+        balances: {
+          "2022-07-13": {
+            block_number: 2000,
+            balance_wei: "2000000000000000000", // 2 ETH
+          },
+          "2022-07-14": {
+            block_number: 3000,
+            balance_wei: "2500000000000000000", // 2.5 ETH
+          },
+        },
+      };
+
+      // Setup balance data for third distributor
+      const balanceData3: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD",
+        },
+        balances: {
+          "2022-07-14": {
+            block_number: 3000,
+            balance_wei: "3000000000000000000", // 3 ETH
+          },
+        },
+      };
+
+      // Setup events for first distributor
+      const eventsData1 = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          last_scanned_block: 2000,
+        },
+        events: {
+          "0xaaaa000000000000000000000000000000000000000000000000000000000001:0":
+            {
+              blockNumber: 1500,
+              transactionHash:
+                "0xaaaa000000000000000000000000000000000000000000000000000000000001",
+              logIndex: 0,
+              address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              value: "100000000000000000", // 0.1 ETH
+            },
+        },
+      };
+
+      // Setup events for second distributor
+      const eventsData2 = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+          last_scanned_block: 3000,
+        },
+        events: {
+          "0xbbbb000000000000000000000000000000000000000000000000000000000001:0":
+            {
+              blockNumber: 2500,
+              transactionHash:
+                "0xbbbb000000000000000000000000000000000000000000000000000000000001",
+              logIndex: 0,
+              address: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+              topics: ["0xRecipientRecievedTopic"],
+              data: "0x",
+              recipient: "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD",
+              value: "200000000000000000", // 0.2 ETH
+            },
+        },
+      };
+
+      // Write all test data
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData1,
+      );
+      fileManager.writeDistributorBalances(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+        balanceData2,
+      );
+      fileManager.writeDistributorBalances(
+        "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD",
+        balanceData3,
+      );
+      fileManager.writeRecipientRecievedEvents(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        eventsData1,
+      );
+      fileManager.writeRecipientRecievedEvents(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+        eventsData2,
+      );
+
+      // Calculate fees
+      calculator.calculateFees();
+
+      // Read and verify the fee report
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+      expect(feeReport!.metadata.chain_id).toBe(42170);
+
+      // Verify all three distributors are included in the report
+      expect(feeReport!.distributors).toHaveProperty(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      );
+      expect(feeReport!.distributors).toHaveProperty(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+      );
+      expect(feeReport!.distributors).toHaveProperty(
+        "0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD",
+      );
+
+      // Verify first distributor's data
+      const distributor1Report =
+        feeReport!.distributors["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(distributor1Report).toHaveLength(2);
+
+      const d1Day1 = distributor1Report![0]!;
+      expect(d1Day1.date).toBe("2022-07-12");
+      expect(d1Day1.balance_change_wei).toBe("1000000000000000000"); // First day
+      expect(d1Day1.distributions_wei).toBe("0");
+      expect(d1Day1.total_wei).toBe("1000000000000000000");
+
+      const d1Day2 = distributor1Report![1]!;
+      expect(d1Day2.date).toBe("2022-07-13");
+      expect(d1Day2.balance_change_wei).toBe("500000000000000000"); // 1.5 - 1.0
+      expect(d1Day2.distributions_wei).toBe("100000000000000000"); // 0.1 ETH event
+      expect(d1Day2.distributions_count).toBe(1);
+      expect(d1Day2.total_wei).toBe("600000000000000000");
+
+      // Verify second distributor's data
+      const distributor2Report =
+        feeReport!.distributors["0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9"];
+      expect(distributor2Report).toHaveLength(2);
+
+      const d2Day1 = distributor2Report![0]!;
+      expect(d2Day1.date).toBe("2022-07-13");
+      expect(d2Day1.balance_change_wei).toBe("2000000000000000000"); // First day
+      expect(d2Day1.distributions_wei).toBe("0");
+      expect(d2Day1.total_wei).toBe("2000000000000000000");
+
+      const d2Day2 = distributor2Report![1]!;
+      expect(d2Day2.date).toBe("2022-07-14");
+      expect(d2Day2.balance_change_wei).toBe("500000000000000000"); // 2.5 - 2.0
+      expect(d2Day2.distributions_wei).toBe("200000000000000000"); // 0.2 ETH event
+      expect(d2Day2.distributions_count).toBe(1);
+      expect(d2Day2.total_wei).toBe("700000000000000000");
+
+      // Verify third distributor's data
+      const distributor3Report =
+        feeReport!.distributors["0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD"];
+      expect(distributor3Report).toHaveLength(1);
+
+      const d3Day1 = distributor3Report![0]!;
+      expect(d3Day1.date).toBe("2022-07-14");
+      expect(d3Day1.balance_change_wei).toBe("3000000000000000000"); // First day
+      expect(d3Day1.distributions_wei).toBe("0"); // No events
+      expect(d3Day1.distributions_count).toBe(0);
+      expect(d3Day1.total_wei).toBe("3000000000000000000");
+    });
   });
 });

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -34,34 +34,40 @@ export class FeeCalculator {
 
     // Process each distributor
     for (const distributorAddress of distributorAddresses) {
-      // Read balance data for the distributor
-      const balanceData =
-        this.fileManager.readDistributorBalances(distributorAddress);
-      if (!balanceData) continue;
-
-      // Get all dates from balance data and sort chronologically
-      const sortedDates = Object.keys(balanceData.balances).sort();
-      if (sortedDates.length === 0) continue;
-
-      // Read distribution events for the distributor
-      const eventsData =
-        this.fileManager.readRecipientRecievedEvents(distributorAddress);
-
-      // Process all dates to create daily entries
-      const dailyEntries = this.createDailyEntries(
-        sortedDates,
-        balanceData.balances,
-        eventsData,
-      );
-
-      // Add this distributor's entries to the report
-      feeReport.distributors[distributorAddress] = dailyEntries;
+      const dailyEntries = this.processDistributor(distributorAddress);
+      if (dailyEntries) {
+        feeReport.distributors[distributorAddress] = dailyEntries;
+      }
     }
 
     // Only write the report if we have data for at least one distributor
     if (Object.keys(feeReport.distributors).length > 0) {
       this.fileManager.writeFeeReport(feeReport);
     }
+  }
+
+  private processDistributor(
+    distributorAddress: string,
+  ): FeeReportEntry[] | null {
+    // Read balance data for the distributor
+    const balanceData =
+      this.fileManager.readDistributorBalances(distributorAddress);
+    if (!balanceData) return null;
+
+    // Get all dates from balance data and sort chronologically
+    const sortedDates = Object.keys(balanceData.balances).sort();
+    if (sortedDates.length === 0) return null;
+
+    // Read distribution events for the distributor
+    const eventsData =
+      this.fileManager.readRecipientRecievedEvents(distributorAddress);
+
+    // Process all dates to create daily entries
+    return this.createDailyEntries(
+      sortedDates,
+      balanceData.balances,
+      eventsData,
+    );
   }
 
   private createDailyEntries(

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -20,45 +20,48 @@ export class FeeCalculator {
     const distributorsData = this.fileManager.readDistributors();
     if (!distributorsData) return;
 
-    // Get first distributor
+    // Get all distributor addresses
     const distributorAddresses = Object.keys(distributorsData.distributors);
     if (distributorAddresses.length === 0) return;
 
-    const firstDistributorAddress = distributorAddresses[0]!;
-
-    // Read balance data for the first distributor
-    const balanceData = this.fileManager.readDistributorBalances(
-      firstDistributorAddress,
-    );
-    if (!balanceData) return;
-
-    // Get all dates from balance data and sort chronologically
-    const sortedDates = Object.keys(balanceData.balances).sort();
-    if (sortedDates.length === 0) return;
-
-    // Read distribution events for the first distributor
-    const eventsData = this.fileManager.readRecipientRecievedEvents(
-      firstDistributorAddress,
-    );
-
-    // Process all dates to create daily entries
-    const dailyEntries = this.createDailyEntries(
-      sortedDates,
-      balanceData.balances,
-      eventsData,
-    );
-
-    // Create and write fee report
+    // Initialize the fee report structure
     const feeReport: FeeReport = {
       metadata: {
         chain_id: distributorsData.metadata.chain_id,
       },
-      distributors: {
-        [firstDistributorAddress]: dailyEntries,
-      },
+      distributors: {},
     };
 
-    this.fileManager.writeFeeReport(feeReport);
+    // Process each distributor
+    for (const distributorAddress of distributorAddresses) {
+      // Read balance data for the distributor
+      const balanceData =
+        this.fileManager.readDistributorBalances(distributorAddress);
+      if (!balanceData) continue;
+
+      // Get all dates from balance data and sort chronologically
+      const sortedDates = Object.keys(balanceData.balances).sort();
+      if (sortedDates.length === 0) continue;
+
+      // Read distribution events for the distributor
+      const eventsData =
+        this.fileManager.readRecipientRecievedEvents(distributorAddress);
+
+      // Process all dates to create daily entries
+      const dailyEntries = this.createDailyEntries(
+        sortedDates,
+        balanceData.balances,
+        eventsData,
+      );
+
+      // Add this distributor's entries to the report
+      feeReport.distributors[distributorAddress] = dailyEntries;
+    }
+
+    // Only write the report if we have data for at least one distributor
+    if (Object.keys(feeReport.distributors).length > 0) {
+      this.fileManager.writeFeeReport(feeReport);
+    }
   }
 
   private createDailyEntries(


### PR DESCRIPTION
## Summary
- Process all distributors returned by FileManager, not just the first one
- Each distributor's data is now included in the final report, keyed by address
- Maintains sequential processing as per requirements

## Context
Resolves #197 

Previously, the FeeCalculator only processed the first distributor in the list, limiting its usefulness for complete fee tracking. This PR extends the `calculateFees` method to process all distributors.

## Implementation
Used strict TDD methodology:
1. **RED**: Wrote failing tests that verify all distributors are processed
2. **GREEN**: Implemented minimal code to make tests pass
3. **REFACTOR**: Extracted distributor processing logic to separate method for better organization

## Changes
- Modified `calculateFees` to loop through all distributors
- Extracted `processDistributor` method for cleaner code organization
- Added comprehensive tests including edge cases for mixed data availability

## Test plan
- [x] All existing tests pass
- [x] New test verifies multiple distributors are processed
- [x] Edge case tests for mixed data availability scenarios
- [x] Edge case test for when no distributors have valid data
- [x] Manual verification with multiple distributor setup