### PR TITLE
feat: create CLI entry point executable file

### DIFF
--- a/__tests__/units/cli.test.ts
+++ b/__tests__/units/cli.test.ts
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+
+describe("CLI Entry Point", () => {
+  const cliPath = path.join(__dirname, "../../src/cli.ts");
+  const compiledCliPath = path.join(__dirname, "../../dist/src/cli.js");
+
+  describe("Source File", () => {
+    it("should exist at src/cli.ts", () => {
+      expect(fs.existsSync(cliPath)).toBe(true);
+    });
+
+    it("should have proper Node.js shebang", () => {
+      const content = fs.readFileSync(cliPath, "utf-8");
+      expect(content.startsWith("#!/usr/bin/env node")).toBe(true);
+    });
+  });
+
+  describe("Compiled File", () => {
+    it("should exist at dist/src/cli.js after build", () => {
+      expect(fs.existsSync(compiledCliPath)).toBe(true);
+    });
+
+    it("should have executable permissions", () => {
+      const stats = fs.statSync(compiledCliPath);
+      const isExecutable = (stats.mode & parseInt("111", 8)) !== 0;
+      expect(isExecutable).toBe(true);
+    });
+  });
+
+  describe("Package Configuration", () => {
+    it("should have bin field in package.json pointing to the CLI", () => {
+      const packageJsonPath = path.join(__dirname, "../../package.json");
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+
+      expect(packageJson.bin).toBeDefined();
+      expect(packageJson.bin.aep).toBe("dist/src/cli.js");
+    });
+  });
+
+  describe("Basic Execution", () => {
+    it("should execute without errors when no arguments provided", () => {
+      const cliCommand = path.join(__dirname, "../../dist/src/cli.js");
+
+      expect(() => {
+        execSync(cliCommand, { stdio: "pipe" });
+      }).not.toThrow();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "AEP fee tracker util",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "bin": {
+    "aep": "dist/src/cli.js"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+// CLI entry point for AEP Fee Calculator
+// This file serves as the executable entry point for the command-line interface
+
+// Placeholder implementation - component orchestration will be added in separate issues
+process.exit(0);


### PR DESCRIPTION
## Summary
- Created CLI entry point executable file at `src/cli.ts` with proper Node.js shebang
- Updated `package.json` to include bin field that maps `aep` command to the compiled CLI
- Added comprehensive tests following TDD methodology

## Implementation Details
This PR implements the minimal CLI entry point as specified in issue #217. The implementation:
- Creates a TypeScript file that compiles to an executable JavaScript file
- Adds proper shebang (`#\!/usr/bin/env node`) for Node.js execution
- Configures package.json with bin field to enable `aep` command
- Includes placeholder implementation that exits cleanly

## What's NOT included (out of scope)
As specified in the issue, the following are explicitly NOT included:
- Argument parsing logic
- Component orchestration 
- Error handling

These will be handled in separate issues.

## Test Plan
- [x] Unit tests verify CLI file exists with proper shebang
- [x] Tests verify compiled file has executable permissions
- [x] Tests verify package.json bin configuration
- [x] Tests verify basic execution without errors
- [x] All existing tests continue to pass

Closes #217