### PR TITLE
feat: add error handling for missing critical data in FeeCalculator

### DIFF
--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -1719,5 +1719,74 @@ describe("FeeCalculator - Integration Tests", () => {
       const feeReport = fileManager.readFeeReport();
       expect(feeReport).toBeUndefined();
     });
+
+    it("should gracefully handle missing distribution events without throwing", () => {
+      const { fileManager } = testContext;
+
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        },
+        balances: {
+          "2022-07-12": {
+            block_number: 152,
+            balance_wei: "1000000000000000000",
+          },
+          "2022-07-13": {
+            block_number: 200,
+            balance_wei: "2000000000000000000",
+          },
+        },
+      };
+
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        balanceData,
+      );
+
+      // Mock FileManager to return undefined for events
+      jest
+        .spyOn(fileManager, "readRecipientRecievedEvents")
+        .mockReturnValue(undefined);
+
+      // Should not throw and treat missing events as 0 distributions
+      calculator.calculateFees();
+
+      const feeReport = fileManager.readFeeReport();
+      expect(feeReport).toBeDefined();
+
+      const distributorReport =
+        feeReport!.distributors["0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB"];
+      expect(distributorReport).toHaveLength(2);
+
+      // Verify distributions are 0 when events are missing
+      expect(distributorReport![0]!.distributions_wei).toBe("0");
+      expect(distributorReport![0]!.distributions_count).toBe(0);
+      expect(distributorReport![1]!.distributions_wei).toBe("0");
+      expect(distributorReport![1]!.distributions_count).toBe(0);
+    });
   });
 });

--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -104,10 +104,43 @@ describe("FeeCalculator - Integration Tests", () => {
       expect(entry!.total_wei).toBe("1000000000000000000");
     });
 
-    it("should handle empty distributor data", () => {
+    it("should throw error when no distributor data exists", () => {
+      // Calculate fees without any data
+      expect(() => {
+        calculator.calculateFees();
+      }).toThrow(
+        "Failed to load distributor data\n  FileManager returned no distributor list\n  Check: Ensure distributor data has been populated by the distributor detector component",
+      );
+    });
+
+    it("should throw error when distributor list cannot be loaded", () => {
       const { fileManager } = testContext;
 
-      // Calculate fees without any data
+      // Mock FileManager to return undefined for readDistributors
+      jest.spyOn(fileManager, "readDistributors").mockReturnValue(undefined);
+
+      // Should throw descriptive error
+      expect(() => {
+        calculator.calculateFees();
+      }).toThrow(
+        "Failed to load distributor data\n  FileManager returned no distributor list\n  Check: Ensure distributor data has been populated by the distributor detector component",
+      );
+    });
+
+    it("should handle empty distributors list without error", () => {
+      const { fileManager } = testContext;
+
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {},
+      };
+
+      fileManager.writeDistributors(distributorsData);
+
+      // Should not throw when distributors list is empty
       calculator.calculateFees();
 
       // Should not write any fee report

--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -169,7 +169,7 @@ describe("FeeCalculator - Integration Tests", () => {
       );
     });
 
-    it("should handle distributor with no balance data", () => {
+    it("should throw error when balance data is missing for a specific distributor", () => {
       const { fileManager } = testContext;
 
       const distributorsData: DistributorsData = {
@@ -195,12 +195,87 @@ describe("FeeCalculator - Integration Tests", () => {
 
       fileManager.writeDistributors(distributorsData);
 
-      // Calculate fees
+      // Mock FileManager to return undefined for balance data
+      jest
+        .spyOn(fileManager, "readDistributorBalances")
+        .mockReturnValue(undefined);
+
+      // Should throw descriptive error when specific distributor is requested
+      expect(() => {
+        calculator.calculateFees("0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB");
+      }).toThrow(
+        "Failed to load balance data for distributor\n  Distributor: 0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB\n  FileManager returned no balance data\n  Check: Ensure balance fetcher has processed this distributor",
+      );
+    });
+
+    it("should skip distributors without balance data when processing all", () => {
+      const { fileManager } = testContext;
+
+      const distributorsData: DistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+          "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9": {
+            type: DistributorType.L1_SURPLUS_FEE,
+            block: 200,
+            date: "2022-07-13",
+            tx_hash:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            method: "0x934be07d",
+            owner: "0x0000000000000000000000000000000000000070",
+            event_data: "event data 2",
+            is_reward_distributor: true,
+            distributor_address: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+          },
+        },
+      };
+
+      const balanceData: BalanceData = {
+        metadata: {
+          chain_id: 42170,
+          reward_distributor: "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+        },
+        balances: {
+          "2022-07-13": {
+            block_number: 200,
+            balance_wei: "1000000000000000000",
+          },
+        },
+      };
+
+      fileManager.writeDistributors(distributorsData);
+      fileManager.writeDistributorBalances(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+        balanceData,
+      );
+      // First distributor has no balance data
+
+      // Should not throw and process only distributor with data
       calculator.calculateFees();
 
-      // Should not write any fee report
       const feeReport = fileManager.readFeeReport();
-      expect(feeReport).toBeUndefined();
+      expect(feeReport).toBeDefined();
+      expect(Object.keys(feeReport!.distributors)).toHaveLength(1);
+      expect(feeReport!.distributors).toHaveProperty(
+        "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+      );
+      expect(feeReport!.distributors).not.toHaveProperty(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      );
     });
 
     it("should handle distributor with empty balance data", () => {

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -54,7 +54,10 @@ export class FeeCalculator {
 
     // Process each distributor
     for (const distributorAddress of distributorAddresses) {
-      const dailyEntries = this.processDistributor(distributorAddress);
+      const dailyEntries = this.processDistributor(
+        distributorAddress,
+        distributorAddresses.length === 1,
+      );
       if (dailyEntries) {
         feeReport.distributors[distributorAddress] = dailyEntries;
       }
@@ -68,11 +71,19 @@ export class FeeCalculator {
 
   private processDistributor(
     distributorAddress: string,
+    isSpecificDistributor: boolean,
   ): FeeReportEntry[] | null {
     // Read balance data for the distributor
     const balanceData =
       this.fileManager.readDistributorBalances(distributorAddress);
-    if (!balanceData) return null;
+    if (!balanceData) {
+      if (isSpecificDistributor) {
+        throw new Error(
+          `Failed to load balance data for distributor\n  Distributor: ${distributorAddress}\n  FileManager returned no balance data\n  Check: Ensure balance fetcher has processed this distributor`,
+        );
+      }
+      return null;
+    }
 
     // Get all dates from balance data and sort chronologically
     const sortedDates = Object.keys(balanceData.balances).sort();

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -17,7 +17,11 @@ export class FeeCalculator {
   calculateFees(distributorAddress?: string): void {
     // Read distributor list
     const distributorsData = this.fileManager.readDistributors();
-    if (!distributorsData) return;
+    if (!distributorsData) {
+      throw new Error(
+        "Failed to load distributor data\n  FileManager returned no distributor list\n  Check: Ensure distributor data has been populated by the distributor detector component",
+      );
+    }
 
     // Get all distributor addresses
     let distributorAddresses = Object.keys(distributorsData.distributors);

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -1,4 +1,9 @@
-import { FileManager, FeeReport, RecipientRecievedEventData } from "./types";
+import {
+  FileManager,
+  FeeReport,
+  RecipientRecievedEventData,
+  FeeCalculatorError,
+} from "./types";
 
 // Type for individual fee report entries
 type FeeReportEntry = {
@@ -18,8 +23,10 @@ export class FeeCalculator {
     // Read distributor list
     const distributorsData = this.fileManager.readDistributors();
     if (!distributorsData) {
-      throw new Error(
+      throw new FeeCalculatorError(
         "Failed to load distributor data\n  FileManager returned no distributor list\n  Check: Ensure distributor data has been populated by the distributor detector component",
+        "calculateFees",
+        { missingData: "distributors" },
       );
     }
 
@@ -29,13 +36,23 @@ export class FeeCalculator {
     // Check if distributor address is provided
     if (distributorAddress) {
       if (distributorAddresses.length === 0) {
-        throw new Error(
+        throw new FeeCalculatorError(
           `No distributors found in data while searching for ${distributorAddress}`,
+          "calculateFees",
+          {
+            distributor: distributorAddress,
+            missingData: "empty distributors list",
+          },
         );
       }
       if (!distributorsData.distributors[distributorAddress]) {
-        throw new Error(
+        throw new FeeCalculatorError(
           `Distributor address ${distributorAddress} not found in distributor data`,
+          "calculateFees",
+          {
+            distributor: distributorAddress,
+            missingData: "distributor not in list",
+          },
         );
       }
       distributorAddresses = [distributorAddress];
@@ -78,8 +95,10 @@ export class FeeCalculator {
       this.fileManager.readDistributorBalances(distributorAddress);
     if (!balanceData) {
       if (isSpecificDistributor) {
-        throw new Error(
+        throw new FeeCalculatorError(
           `Failed to load balance data for distributor\n  Distributor: ${distributorAddress}\n  FileManager returned no balance data\n  Check: Ensure balance fetcher has processed this distributor`,
+          "processDistributor",
+          { distributor: distributorAddress, missingData: "balance data" },
         );
       }
       return null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -217,6 +217,21 @@ export class RPCError extends Error {
   }
 }
 
+export class FeeCalculatorError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly context: {
+      distributor?: string;
+      missingData?: string;
+      cause?: Error;
+    },
+  ) {
+    super(message);
+    this.name = "FeeCalculatorError";
+  }
+}
+
 // Type Guards
 export function isValidDistributorType(type: string): type is DistributorType {
   return Object.values(DistributorType).includes(type as DistributorType);


### PR DESCRIPTION
## Summary
- Adds error handling to FeeCalculator for missing critical data as specified in issue #199
- Throws descriptive errors when distributor list cannot be loaded from FileManager
- Throws errors when balance data is missing for a specifically requested distributor
- Continues to handle missing distribution events gracefully (treats as 0)

## Changes
1. **Error for missing distributor data**: When FileManager returns null/undefined for distributor list, throw a descriptive error
2. **Error for missing balance data**: When a specific distributor is requested but has no balance data, throw an error
3. **Graceful handling for batch processing**: When processing all distributors, skip ones without balance data (existing behavior)
4. **Custom error class**: Added `FeeCalculatorError` class for consistent error handling following patterns from BlockFinder

## Test Plan
✅ Added test for error when distributor list cannot be loaded
✅ Added test for error when balance data is missing for a specific distributor  
✅ Added test to verify missing events are still handled gracefully
✅ All existing tests pass
✅ Error messages are descriptive and include context

Closes #199