### PR TITLE
feat: create configuration module from parsed arguments

### DIFF
--- a/__tests__/units/configuration.test.ts
+++ b/__tests__/units/configuration.test.ts
@@ -36,5 +36,16 @@ describe("Configuration Module", () => {
 
       expect(config.storeDirectory).toBe("/data/aep-fees");
     });
+
+    it("should include RPC URL in configuration", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.rpcUrl).toBe("https://archive-node.com/rpc");
+    });
   });
 });

--- a/__tests__/units/configuration.test.ts
+++ b/__tests__/units/configuration.test.ts
@@ -24,5 +24,17 @@ describe("Configuration Module", () => {
 
       expect(config.storeDirectory).toBe("./store");
     });
+
+    it("should use provided store directory", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        "store-dir": "/data/aep-fees",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.storeDirectory).toBe("/data/aep-fees");
+    });
   });
 });

--- a/__tests__/units/configuration.test.ts
+++ b/__tests__/units/configuration.test.ts
@@ -47,5 +47,41 @@ describe("Configuration Module", () => {
 
       expect(config.rpcUrl).toBe("https://archive-node.com/rpc");
     });
+
+    it("should include start date when provided", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        "start-date": "2024-01-01",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.startDate).toBe("2024-01-01");
+    });
+
+    it("should include end date when provided", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        "end-date": "2024-01-31",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.endDate).toBe("2024-01-31");
+    });
+
+    it("should not include dates when not provided", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.startDate).toBeUndefined();
+      expect(config.endDate).toBeUndefined();
+    });
   });
 });

--- a/__tests__/units/configuration.test.ts
+++ b/__tests__/units/configuration.test.ts
@@ -1,0 +1,17 @@
+import { createConfiguration } from "../../src/configuration";
+import { ParsedArguments } from "../../src/parse-arguments";
+
+describe("Configuration Module", () => {
+  describe("createConfiguration", () => {
+    it("should create configuration from parsed arguments", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config).toBeDefined();
+    });
+  });
+});

--- a/__tests__/units/configuration.test.ts
+++ b/__tests__/units/configuration.test.ts
@@ -13,5 +13,16 @@ describe("Configuration Module", () => {
 
       expect(config).toBeDefined();
     });
+
+    it("should apply default store directory when not provided", () => {
+      const parsedArgs: ParsedArguments = {
+        "rpc-url": "https://archive-node.com/rpc",
+        _: [],
+      };
+
+      const config = createConfiguration(parsedArgs);
+
+      expect(config.storeDirectory).toBe("./store");
+    });
   });
 });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,7 @@
+import { ParsedArguments } from "./parse-arguments";
+
+export function createConfiguration(parsedArgs: ParsedArguments) {
+  // Minimal implementation to make test pass
+  void parsedArgs;
+  return {};
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,10 +1,23 @@
 import { ParsedArguments } from "./parse-arguments";
+import { Configuration } from "./types";
 
-export function createConfiguration(parsedArgs: ParsedArguments) {
-  return {
-    storeDirectory: parsedArgs["store-dir"] || "./store",
+const DEFAULT_STORE_DIRECTORY = "./store";
+
+export function createConfiguration(
+  parsedArgs: ParsedArguments,
+): Configuration {
+  const config: Configuration = {
+    storeDirectory: parsedArgs["store-dir"] || DEFAULT_STORE_DIRECTORY,
     rpcUrl: parsedArgs["rpc-url"]!,
-    startDate: parsedArgs["start-date"],
-    endDate: parsedArgs["end-date"],
   };
+
+  if (parsedArgs["start-date"]) {
+    config.startDate = parsedArgs["start-date"];
+  }
+
+  if (parsedArgs["end-date"]) {
+    config.endDate = parsedArgs["end-date"];
+  }
+
+  return config;
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,5 +3,7 @@ import { ParsedArguments } from "./parse-arguments";
 export function createConfiguration(parsedArgs: ParsedArguments) {
   // Minimal implementation to make test pass
   void parsedArgs;
-  return {};
+  return {
+    storeDirectory: "./store",
+  };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,5 +3,6 @@ import { ParsedArguments } from "./parse-arguments";
 export function createConfiguration(parsedArgs: ParsedArguments) {
   return {
     storeDirectory: parsedArgs["store-dir"] || "./store",
+    rpcUrl: parsedArgs["rpc-url"]!,
   };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,7 @@
 import { ParsedArguments } from "./parse-arguments";
 
 export function createConfiguration(parsedArgs: ParsedArguments) {
-  // Minimal implementation to make test pass
-  void parsedArgs;
   return {
-    storeDirectory: "./store",
+    storeDirectory: parsedArgs["store-dir"] || "./store",
   };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,5 +4,7 @@ export function createConfiguration(parsedArgs: ParsedArguments) {
   return {
     storeDirectory: parsedArgs["store-dir"] || "./store",
     rpcUrl: parsedArgs["rpc-url"]!,
+    startDate: parsedArgs["start-date"],
+    endDate: parsedArgs["end-date"],
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,13 @@ export {
 
 // Core Data Types
 
+export interface Configuration {
+  storeDirectory: string;
+  rpcUrl: string;
+  startDate?: string;
+  endDate?: string;
+}
+
 export interface BlockNumberData {
   metadata: {
     chain_id: number;


### PR DESCRIPTION
## Summary
- Created configuration module to transform parsed CLI arguments into structured configuration object
- Applied default store directory './store' when not provided
- Included RPC URL and optional date parameters in configuration
- Followed strict TDD approach with comprehensive tests

## Implementation Details
This PR implements issue #219 to create a configuration module that:
- Transforms `ParsedArguments` into a typed `Configuration` object
- Applies the default store directory of `'./store'` if not provided
- Passes through the RPC URL (required)
- Includes optional `start-date` and `end-date` parameters when provided
- Returns a properly typed configuration object for use by components

## TDD Process
Followed red-green-refactor cycle:
1. **RED**: Wrote failing tests for each requirement
2. **GREEN**: Implemented minimal code to make tests pass
3. **REFACTOR**: Improved code quality with:
   - Added `Configuration` interface to types/index.ts
   - Extracted `DEFAULT_STORE_DIRECTORY` constant
   - Added proper TypeScript types
   - Handled optional properties correctly for strict mode

## Test Coverage
All tests passing with 100% coverage for the new module:
- Configuration export and creation
- Default store directory behavior
- Provided store directory pass-through
- RPC URL inclusion
- Optional date parameter handling

## Blocking Issues
This was blocked by #218 (argument parser) which has been completed.

Resolves #219