### PR TITLE
Fix: Correct start_balance_wei calculation in FeeCalculator

### DIFF
--- a/__tests__/integration/fee-calculator-integration.test.ts
+++ b/__tests__/integration/fee-calculator-integration.test.ts
@@ -96,7 +96,7 @@ describe("FeeCalculator - Integration Tests", () => {
 
       const entry = distributorReport![0];
       expect(entry!.date).toBe("2022-07-12");
-      expect(entry!.start_balance_wei).toBe("1000000000000000000");
+      expect(entry!.start_balance_wei).toBe("0"); // First day starts with 0
       expect(entry!.end_balance_wei).toBe("1000000000000000000");
       expect(entry!.balance_change_wei).toBe("1000000000000000000");
       expect(entry!.distributions_wei).toBe("0");
@@ -579,7 +579,7 @@ describe("FeeCalculator - Integration Tests", () => {
       // First day - balance change should be the balance itself (1 ETH)
       const day1 = distributorReport![0];
       expect(day1!.date).toBe("2022-07-12");
-      expect(day1!.start_balance_wei).toBe("1000000000000000000");
+      expect(day1!.start_balance_wei).toBe("0"); // First day starts with 0
       expect(day1!.end_balance_wei).toBe("1000000000000000000");
       expect(day1!.balance_change_wei).toBe("1000000000000000000");
       expect(day1!.distributions_wei).toBe("0");
@@ -589,7 +589,7 @@ describe("FeeCalculator - Integration Tests", () => {
       // Second day - balance change should be 500000000000000000 (1.5 - 1.0 ETH)
       const day2 = distributorReport![1];
       expect(day2!.date).toBe("2022-07-13");
-      expect(day2!.start_balance_wei).toBe("1500000000000000000");
+      expect(day2!.start_balance_wei).toBe("1000000000000000000"); // Previous day's end balance
       expect(day2!.end_balance_wei).toBe("1500000000000000000");
       expect(day2!.balance_change_wei).toBe("500000000000000000");
       expect(day2!.distributions_wei).toBe("0");
@@ -599,7 +599,7 @@ describe("FeeCalculator - Integration Tests", () => {
       // Third day - balance change should be 1000000000000000000 (2.5 - 1.5 ETH)
       const day3 = distributorReport![2];
       expect(day3!.date).toBe("2022-07-14");
-      expect(day3!.start_balance_wei).toBe("2500000000000000000");
+      expect(day3!.start_balance_wei).toBe("1500000000000000000"); // Previous day's end balance
       expect(day3!.end_balance_wei).toBe("2500000000000000000");
       expect(day3!.balance_change_wei).toBe("1000000000000000000");
       expect(day3!.distributions_wei).toBe("0");

--- a/__tests__/units/fee-calculator.test.ts
+++ b/__tests__/units/fee-calculator.test.ts
@@ -48,7 +48,8 @@ describe("FeeCalculator Unit Tests", () => {
       const calculatorWithPrivates = calculator as unknown as {
         createDailyEntry: (
           date: string,
-          balanceWei: string,
+          previousBalanceWei: string,
+          currentBalanceWei: string,
           balanceChangeWei: bigint,
           distributionsWei: bigint,
           distributionsCount: number,
@@ -65,21 +66,19 @@ describe("FeeCalculator Unit Tests", () => {
       const createDailyEntry =
         calculatorWithPrivates.createDailyEntry.bind(calculator);
 
-      // Note: Current implementation only accepts currentBalanceWei
-      // After fix, it should accept both previousBalanceWei and currentBalanceWei
+      // Now the implementation accepts both previousBalanceWei and currentBalanceWei
       const result = createDailyEntry(
         date,
+        previousBalanceWei,
         currentBalanceWei,
         balanceChangeWei,
         distributionsWei,
         distributionsCount,
       );
 
-      // This test will FAIL with current implementation because:
-      // - start_balance_wei is set to currentBalanceWei instead of previousBalanceWei
-      // - Both start and end are set to the same value
+      // Verify the result
       expect(result.date).toBe(date);
-      expect(result.start_balance_wei).toBe(previousBalanceWei); // FAILS: Gets currentBalanceWei
+      expect(result.start_balance_wei).toBe(previousBalanceWei);
       expect(result.end_balance_wei).toBe(currentBalanceWei);
       expect(result.balance_change_wei).toBe("-20000000000000000000");
       expect(result.distributions_wei).toBe("25000000000000000000");

--- a/__tests__/units/fee-calculator.test.ts
+++ b/__tests__/units/fee-calculator.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { FeeCalculator } from "../../src/fee-calculator";
+import { FileManager } from "../../src/types";
+
+describe("FeeCalculator Unit Tests", () => {
+  let mockFileManager: jest.Mocked<FileManager>;
+  let calculator: FeeCalculator;
+
+  beforeEach(() => {
+    // Create a mock FileManager
+    mockFileManager = {
+      readBlockNumbers: jest.fn(),
+      writeBlockNumbers: jest.fn(),
+      readDistributors: jest.fn(),
+      writeDistributors: jest.fn(),
+      readDistributorBalances: jest.fn(),
+      writeDistributorBalances: jest.fn(),
+      readRecipientRecievedEvents: jest.fn(),
+      writeRecipientRecievedEvents: jest.fn(),
+      readFeeReport: jest.fn(),
+      writeFeeReport: jest.fn(),
+      ensureStoreDirectory: jest.fn(),
+      validateAddress: jest.fn(),
+      formatDate: jest.fn(),
+      validateDateFormat: jest.fn(),
+      validateBlockNumber: jest.fn(),
+      validateWeiValue: jest.fn(),
+      validateTransactionHash: jest.fn(),
+      validateEnumValue: jest.fn(),
+    } as jest.Mocked<FileManager>;
+
+    calculator = new FeeCalculator(mockFileManager);
+  });
+
+  describe("createDailyEntry", () => {
+    it("should set start_balance_wei to previous balance and end_balance_wei to current balance", () => {
+      // Test data matching the spec example
+      const date = "2024-01-15";
+      const previousBalanceWei = "1500000000000000000000"; // 1500 ETH (start balance)
+      const currentBalanceWei = "1480000000000000000000"; // 1480 ETH (end balance)
+      const balanceChangeWei = BigInt("-20000000000000000000"); // -20 ETH
+      const distributionsWei = BigInt("25000000000000000000"); // 25 ETH
+      const distributionsCount = 5;
+
+      // Access private method through reflection for unit testing
+      // This test documents the EXPECTED behavior after fix
+      // Using type assertion to access private method for testing purposes
+      const calculatorWithPrivates = calculator as unknown as {
+        createDailyEntry: (
+          date: string,
+          balanceWei: string,
+          balanceChangeWei: bigint,
+          distributionsWei: bigint,
+          distributionsCount: number,
+        ) => {
+          date: string;
+          start_balance_wei: string;
+          end_balance_wei: string;
+          balance_change_wei: string;
+          distributions_wei: string;
+          distributions_count: number;
+          total_wei: string;
+        };
+      };
+      const createDailyEntry =
+        calculatorWithPrivates.createDailyEntry.bind(calculator);
+
+      // Note: Current implementation only accepts currentBalanceWei
+      // After fix, it should accept both previousBalanceWei and currentBalanceWei
+      const result = createDailyEntry(
+        date,
+        currentBalanceWei,
+        balanceChangeWei,
+        distributionsWei,
+        distributionsCount,
+      );
+
+      // This test will FAIL with current implementation because:
+      // - start_balance_wei is set to currentBalanceWei instead of previousBalanceWei
+      // - Both start and end are set to the same value
+      expect(result.date).toBe(date);
+      expect(result.start_balance_wei).toBe(previousBalanceWei); // FAILS: Gets currentBalanceWei
+      expect(result.end_balance_wei).toBe(currentBalanceWei);
+      expect(result.balance_change_wei).toBe("-20000000000000000000");
+      expect(result.distributions_wei).toBe("25000000000000000000");
+      expect(result.distributions_count).toBe(5);
+      expect(result.total_wei).toBe("5000000000000000000"); // -20 + 25 = 5
+    });
+  });
+});

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -113,6 +113,7 @@ export class FeeCalculator {
       dailyEntries.push(
         this.createDailyEntry(
           date,
+          previousBalanceWei,
           currentBalance.balance_wei,
           balanceChangeWei,
           distributionsWei,
@@ -137,7 +138,8 @@ export class FeeCalculator {
 
   private createDailyEntry(
     date: string,
-    balanceWei: string,
+    previousBalanceWei: string,
+    currentBalanceWei: string,
     balanceChangeWei: bigint,
     distributionsWei: bigint,
     distributionsCount: number,
@@ -147,8 +149,8 @@ export class FeeCalculator {
 
     return {
       date,
-      start_balance_wei: balanceWei,
-      end_balance_wei: balanceWei,
+      start_balance_wei: previousBalanceWei,
+      end_balance_wei: currentBalanceWei,
       balance_change_wei: balanceChangeWei.toString(),
       distributions_wei: distributionsWei.toString(),
       distributions_count: distributionsCount,


### PR DESCRIPTION
## Summary
- Fix start_balance_wei to show previous day's balance instead of current day's balance
- Update createDailyEntry method signature to accept both previous and current balance
- Ensure balance_change_wei = end_balance_wei - start_balance_wei invariant is maintained

## Changes
1. Modified `createDailyEntry` to accept `previousBalanceWei` parameter
2. Set `start_balance_wei` to previous balance (0 for first day)
3. Set `end_balance_wei` to current balance
4. Updated integration tests to reflect correct expected values

## Test Plan
- [x] Unit test for createDailyEntry method
- [x] All integration tests updated and passing
- [x] Manual verification of fee report output

Fixes #235