### PR TITLE
feat: add URL validation for RPC endpoint parameter

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,7 +25,7 @@ if [ -f "package.json" ]; then
     else
         # Run TypeScript type checking
         echo "Running TypeScript type check..."
-        if npm run typecheck 2>&1 | grep -E "(error|Error)" > /dev/null; then
+        if ! npm run typecheck; then
             echo "${RED}TypeScript type check failed${NC}"
             exit 1
         fi
@@ -33,7 +33,7 @@ if [ -f "package.json" ]; then
 
         # Run ESLint
         echo "Running ESLint..."
-        if ! npm run lint > /dev/null 2>&1; then
+        if ! npm run lint; then
             echo "${RED}ESLint check failed${NC}"
             echo "Run 'npm run lint:fix' to auto-fix issues"
             exit 1
@@ -42,7 +42,7 @@ if [ -f "package.json" ]; then
 
         # Check Prettier formatting
         echo "Checking code formatting..."
-        if ! npm run format:check > /dev/null 2>&1; then
+        if ! npm run format:check; then
             echo "${RED}Code formatting check failed${NC}"
             echo "Run 'npm run format' to auto-format"
             exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,7 +22,7 @@ if [ -f "package.json" ] && command -v npm > /dev/null 2>&1; then
     
     # Run build to ensure it compiles
     echo "Running build..."
-    if ! npm run build > /dev/null 2>&1; then
+    if ! npm run build; then
         echo "${RED}Build failed${NC}"
         exit 1
     fi

--- a/__tests__/units/cli-argument-parser.test.ts
+++ b/__tests__/units/cli-argument-parser.test.ts
@@ -22,6 +22,46 @@ describe("CLI Argument Parser", () => {
     });
   });
 
+  describe("URL Validation", () => {
+    it("should reject invalid URL without protocol", () => {
+      const args = ["--rpc-url", "archive-node.com/rpc"];
+
+      expect(() => parseArguments(args)).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject invalid URL with wrong protocol", () => {
+      const args = ["--rpc-url", "ftp://archive-node.com"];
+
+      expect(() => parseArguments(args)).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject malformed URL", () => {
+      const args = ["--rpc-url", "https://[invalid"];
+
+      expect(() => parseArguments(args)).toThrow(
+        "Invalid RPC URL: Invalid URL"
+      );
+    });
+
+    it("should accept valid HTTP URL", () => {
+      const args = ["--rpc-url", "http://localhost:8545"];
+      const result = parseArguments(args);
+
+      expect(result["rpc-url"]).toBe("http://localhost:8545");
+    });
+
+    it("should accept valid HTTPS URL", () => {
+      const args = ["--rpc-url", "https://archive-node.com/rpc"];
+      const result = parseArguments(args);
+
+      expect(result["rpc-url"]).toBe("https://archive-node.com/rpc");
+    });
+  });
+
   describe("Optional Arguments", () => {
     it("should parse --start-date argument", () => {
       const args = [

--- a/__tests__/units/cli-argument-parser.test.ts
+++ b/__tests__/units/cli-argument-parser.test.ts
@@ -27,7 +27,7 @@ describe("CLI Argument Parser", () => {
       const args = ["--rpc-url", "archive-node.com/rpc"];
 
       expect(() => parseArguments(args)).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
@@ -35,7 +35,7 @@ describe("CLI Argument Parser", () => {
       const args = ["--rpc-url", "ftp://archive-node.com"];
 
       expect(() => parseArguments(args)).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
@@ -43,7 +43,7 @@ describe("CLI Argument Parser", () => {
       const args = ["--rpc-url", "https://[invalid"];
 
       expect(() => parseArguments(args)).toThrow(
-        "Invalid RPC URL: Invalid URL"
+        "Invalid RPC URL: Invalid URL",
       );
     });
 

--- a/__tests__/units/url-validation.test.ts
+++ b/__tests__/units/url-validation.test.ts
@@ -1,0 +1,110 @@
+import { validateRpcUrl } from "../../src/url-validation";
+
+describe("URL Validation", () => {
+  describe("Valid URLs", () => {
+    it("should accept HTTPS URL", () => {
+      expect(() => validateRpcUrl("https://archive-node.com/rpc")).not.toThrow();
+    });
+
+    it("should accept HTTP URL", () => {
+      expect(() => validateRpcUrl("http://localhost:8545")).not.toThrow();
+    });
+
+    it("should accept URL with port", () => {
+      expect(() => validateRpcUrl("https://node.example.com:8545")).not.toThrow();
+    });
+
+    it("should accept URL with path", () => {
+      expect(() => validateRpcUrl("https://node.example.com/v1/mainnet")).not.toThrow();
+    });
+
+    it("should accept URL with port and path", () => {
+      expect(() => validateRpcUrl("https://node.example.com:8545/v1/mainnet")).not.toThrow();
+    });
+
+    it("should accept URL with query parameters", () => {
+      expect(() => validateRpcUrl("https://node.example.com/rpc?apikey=123")).not.toThrow();
+    });
+
+    it("should accept localhost URLs", () => {
+      expect(() => validateRpcUrl("http://localhost:8545")).not.toThrow();
+      expect(() => validateRpcUrl("http://127.0.0.1:8545")).not.toThrow();
+    });
+  });
+
+  describe("Invalid URLs", () => {
+    it("should reject URL without protocol", () => {
+      expect(() => validateRpcUrl("archive-node.com/rpc")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject URL with invalid protocol", () => {
+      expect(() => validateRpcUrl("ftp://archive-node.com")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject URL with ws protocol", () => {
+      expect(() => validateRpcUrl("ws://archive-node.com")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject URL with wss protocol", () => {
+      expect(() => validateRpcUrl("wss://archive-node.com")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject URL without host", () => {
+      expect(() => validateRpcUrl("https://")).toThrow(
+        "Invalid RPC URL: Invalid URL"
+      );
+    });
+
+    it("should reject completely invalid URL", () => {
+      expect(() => validateRpcUrl("not-a-url")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject empty string", () => {
+      expect(() => validateRpcUrl("")).toThrow(
+        "Invalid RPC URL: URL must start with http:// or https://"
+      );
+    });
+
+    it("should reject URL with spaces", () => {
+      expect(() => validateRpcUrl("https://example .com")).toThrow(
+        "Invalid RPC URL: Invalid URL"
+      );
+    });
+
+    it("should reject malformed URLs", () => {
+      expect(() => validateRpcUrl("https://[invalid")).toThrow(
+        "Invalid RPC URL: Invalid URL"
+      );
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle undefined", () => {
+      expect(() => validateRpcUrl(undefined as any)).toThrow(
+        "Invalid RPC URL: URL is required"
+      );
+    });
+
+    it("should handle null", () => {
+      expect(() => validateRpcUrl(null as any)).toThrow(
+        "Invalid RPC URL: URL is required"
+      );
+    });
+
+    it("should handle non-string values", () => {
+      expect(() => validateRpcUrl(123 as any)).toThrow(
+        "Invalid RPC URL: URL must be a string"
+      );
+    });
+  });
+});

--- a/__tests__/units/url-validation.test.ts
+++ b/__tests__/units/url-validation.test.ts
@@ -3,7 +3,9 @@ import { validateRpcUrl } from "../../src/url-validation";
 describe("URL Validation", () => {
   describe("Valid URLs", () => {
     it("should accept HTTPS URL", () => {
-      expect(() => validateRpcUrl("https://archive-node.com/rpc")).not.toThrow();
+      expect(() =>
+        validateRpcUrl("https://archive-node.com/rpc"),
+      ).not.toThrow();
     });
 
     it("should accept HTTP URL", () => {
@@ -11,19 +13,27 @@ describe("URL Validation", () => {
     });
 
     it("should accept URL with port", () => {
-      expect(() => validateRpcUrl("https://node.example.com:8545")).not.toThrow();
+      expect(() =>
+        validateRpcUrl("https://node.example.com:8545"),
+      ).not.toThrow();
     });
 
     it("should accept URL with path", () => {
-      expect(() => validateRpcUrl("https://node.example.com/v1/mainnet")).not.toThrow();
+      expect(() =>
+        validateRpcUrl("https://node.example.com/v1/mainnet"),
+      ).not.toThrow();
     });
 
     it("should accept URL with port and path", () => {
-      expect(() => validateRpcUrl("https://node.example.com:8545/v1/mainnet")).not.toThrow();
+      expect(() =>
+        validateRpcUrl("https://node.example.com:8545/v1/mainnet"),
+      ).not.toThrow();
     });
 
     it("should accept URL with query parameters", () => {
-      expect(() => validateRpcUrl("https://node.example.com/rpc?apikey=123")).not.toThrow();
+      expect(() =>
+        validateRpcUrl("https://node.example.com/rpc?apikey=123"),
+      ).not.toThrow();
     });
 
     it("should accept localhost URLs", () => {
@@ -35,55 +45,55 @@ describe("URL Validation", () => {
   describe("Invalid URLs", () => {
     it("should reject URL without protocol", () => {
       expect(() => validateRpcUrl("archive-node.com/rpc")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject URL with invalid protocol", () => {
       expect(() => validateRpcUrl("ftp://archive-node.com")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject URL with ws protocol", () => {
       expect(() => validateRpcUrl("ws://archive-node.com")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject URL with wss protocol", () => {
       expect(() => validateRpcUrl("wss://archive-node.com")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject URL without host", () => {
       expect(() => validateRpcUrl("https://")).toThrow(
-        "Invalid RPC URL: Invalid URL"
+        "Invalid RPC URL: Invalid URL",
       );
     });
 
     it("should reject completely invalid URL", () => {
       expect(() => validateRpcUrl("not-a-url")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject empty string", () => {
       expect(() => validateRpcUrl("")).toThrow(
-        "Invalid RPC URL: URL must start with http:// or https://"
+        "Invalid RPC URL: URL must start with http:// or https://",
       );
     });
 
     it("should reject URL with spaces", () => {
       expect(() => validateRpcUrl("https://example .com")).toThrow(
-        "Invalid RPC URL: Invalid URL"
+        "Invalid RPC URL: Invalid URL",
       );
     });
 
     it("should reject malformed URLs", () => {
       expect(() => validateRpcUrl("https://[invalid")).toThrow(
-        "Invalid RPC URL: Invalid URL"
+        "Invalid RPC URL: Invalid URL",
       );
     });
   });
@@ -91,19 +101,19 @@ describe("URL Validation", () => {
   describe("Edge cases", () => {
     it("should handle undefined", () => {
       expect(() => validateRpcUrl(undefined as unknown as string)).toThrow(
-        "Invalid RPC URL: URL is required"
+        "Invalid RPC URL: URL is required",
       );
     });
 
     it("should handle null", () => {
       expect(() => validateRpcUrl(null as unknown as string)).toThrow(
-        "Invalid RPC URL: URL is required"
+        "Invalid RPC URL: URL is required",
       );
     });
 
     it("should handle non-string values", () => {
       expect(() => validateRpcUrl(123 as unknown as string)).toThrow(
-        "Invalid RPC URL: URL must be a string"
+        "Invalid RPC URL: URL must be a string",
       );
     });
   });

--- a/__tests__/units/url-validation.test.ts
+++ b/__tests__/units/url-validation.test.ts
@@ -90,19 +90,19 @@ describe("URL Validation", () => {
 
   describe("Edge cases", () => {
     it("should handle undefined", () => {
-      expect(() => validateRpcUrl(undefined as any)).toThrow(
+      expect(() => validateRpcUrl(undefined as unknown as string)).toThrow(
         "Invalid RPC URL: URL is required"
       );
     });
 
     it("should handle null", () => {
-      expect(() => validateRpcUrl(null as any)).toThrow(
+      expect(() => validateRpcUrl(null as unknown as string)).toThrow(
         "Invalid RPC URL: URL is required"
       );
     });
 
     it("should handle non-string values", () => {
-      expect(() => validateRpcUrl(123 as any)).toThrow(
+      expect(() => validateRpcUrl(123 as unknown as string)).toThrow(
         "Invalid RPC URL: URL must be a string"
       );
     });

--- a/src/parse-arguments.ts
+++ b/src/parse-arguments.ts
@@ -1,4 +1,5 @@
 import minimist from "minimist";
+import { validateRpcUrl } from "./url-validation";
 
 export interface ParsedArguments {
   "rpc-url"?: string;
@@ -18,6 +19,9 @@ export function parseArguments(args: string[]): ParsedArguments {
   if (!parsed["rpc-url"]) {
     throw new Error(`--rpc-url is required\n\n${USAGE_MESSAGE}`);
   }
+
+  // Validate the RPC URL format
+  validateRpcUrl(parsed["rpc-url"]);
 
   return parsed;
 }

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -3,27 +3,21 @@ export function validateRpcUrl(url: string): void {
   if (url === undefined || url === null) {
     throw new Error("Invalid RPC URL: URL is required");
   }
-  
+
   // Check if URL is a string
   if (typeof url !== "string") {
     throw new Error("Invalid RPC URL: URL must be a string");
   }
-  
+
   // Check if URL starts with http:// or https://
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     throw new Error("Invalid RPC URL: URL must start with http:// or https://");
   }
-  
+
   // Try to parse the URL
-  let parsedUrl: URL;
   try {
-    parsedUrl = new URL(url);
-  } catch (error) {
+    new URL(url);
+  } catch {
     throw new Error("Invalid RPC URL: Invalid URL");
-  }
-  
-  // Double-check protocol (redundant but ensures consistency)
-  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw new Error("Invalid RPC URL: URL must start with http:// or https://");
   }
 }

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -1,0 +1,29 @@
+export function validateRpcUrl(url: string): void {
+  // Check if URL is provided
+  if (url === undefined || url === null) {
+    throw new Error("Invalid RPC URL: URL is required");
+  }
+  
+  // Check if URL is a string
+  if (typeof url !== "string") {
+    throw new Error("Invalid RPC URL: URL must be a string");
+  }
+  
+  // Check if URL starts with http:// or https://
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    throw new Error("Invalid RPC URL: URL must start with http:// or https://");
+  }
+  
+  // Try to parse the URL
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    throw new Error("Invalid RPC URL: Invalid URL");
+  }
+  
+  // Double-check protocol (redundant but ensures consistency)
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("Invalid RPC URL: URL must start with http:// or https://");
+  }
+}


### PR DESCRIPTION
## Summary
- Added URL validation for the --rpc-url parameter to ensure it's a valid HTTP/HTTPS URL
- Prevents cryptic errors later in the pipeline by catching invalid URLs early

## Test plan
- Added comprehensive unit tests for URL validation function covering:
  - Valid URLs (HTTP, HTTPS, with ports, paths, query parameters)
  - Invalid URLs (missing protocol, wrong protocol, malformed URLs)
  - Edge cases (null, undefined, non-string values)
- Added integration tests in parse-arguments to ensure validation is properly integrated
- All existing tests continue to pass

## Implementation Details
- Created new `src/url-validation.ts` module following existing pattern from `date-validation.ts`
- Uses Node.js built-in URL constructor for validation
- Provides clear error messages for different failure modes
- Validates that URL starts with http:// or https:// as specified

Closes #224