### PR TITLE
test: add comprehensive package.json CLI configuration tests

### DIFF
--- a/__tests__/units/cli.test.ts
+++ b/__tests__/units/cli.test.ts
@@ -16,12 +16,31 @@ describe("CLI Entry Point", () => {
   });
 
   describe("Package Configuration", () => {
-    it("should have bin field in package.json pointing to the CLI", () => {
-      const packageJsonPath = path.join(__dirname, "../../package.json");
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    const packageJsonPath = path.join(__dirname, "../../package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 
+    it("should have bin field in package.json pointing to the CLI", () => {
       expect(packageJson.bin).toBeDefined();
       expect(packageJson.bin.aep).toBe("dist/src/cli.js");
+    });
+
+    it("should have minimist in dependencies", () => {
+      expect(packageJson.dependencies).toBeDefined();
+      expect(packageJson.dependencies.minimist).toBeDefined();
+      expect(typeof packageJson.dependencies.minimist).toBe("string");
+    });
+
+    it("should have postbuild script to make CLI executable", () => {
+      expect(packageJson.scripts).toBeDefined();
+      expect(packageJson.scripts.postbuild).toBe("chmod +x dist/src/cli.js");
+    });
+
+    it("should have @types/minimist in devDependencies", () => {
+      expect(packageJson.devDependencies).toBeDefined();
+      expect(packageJson.devDependencies["@types/minimist"]).toBeDefined();
+      expect(typeof packageJson.devDependencies["@types/minimist"]).toBe(
+        "string",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added tests to verify package.json CLI configuration for issue #226
- Verified that all requirements from issue #226 have already been implemented

## Test plan
- [x] Run `npm test` - all tests pass
- [x] Verify that package.json has correct bin field configuration
- [x] Verify that minimist is in dependencies
- [x] Verify that postbuild script makes CLI executable
- [x] Verify that @types/minimist is in devDependencies

## Notes
Issue #226 was already completed in previous commits. This PR adds comprehensive tests to ensure the configuration remains correct.

Closes #226