### PR TITLE
Fix: Remove redundant logging of already-processed dates in block finder

### DIFF
--- a/src/block-finder.ts
+++ b/src/block-finder.ts
@@ -85,8 +85,8 @@ export class BlockFinder {
     safeCurrentBlock: number,
   ): Promise<void> {
     const dateStr = this.formatDateString(date);
-    console.log(`Processing date: ${dateStr}`);
     if (result.blocks[dateStr]) return;
+    console.log(`Processing date: ${dateStr}`);
 
     const [lowerBound, upperBound] = this.getSearchBounds(
       date,


### PR DESCRIPTION
## Summary
- Moved log statement after the early return check in `BlockFinder.processDate()`
- Now only logs when actually processing a date for the first time
- No logging occurs for dates that already exist in the store

## What Changed
In `src/block-finder.ts`, the `console.log` statement was moved from line 88 (before the check) to line 89 (after the check):

```typescript
// Before:
console.log(`Processing date: ${dateStr}`);
if (result.blocks[dateStr]) return;

// After:
if (result.blocks[dateStr]) return;
console.log(`Processing date: ${dateStr}`);
```

This ensures that logs only appear when actual work is being performed, reducing log noise and making it easier to see what new work is happening during each run.

## Test plan
- [x] All existing tests pass
- [x] Code compiles without errors
- [x] Linting passes
- [x] Pre-commit hooks pass

Fixes #251