### PR TITLE
Fix: Throw error when calculating fees for non-reward distributor

### DIFF
--- a/__tests__/integration/fee-calculator.test.ts
+++ b/__tests__/integration/fee-calculator.test.ts
@@ -190,7 +190,7 @@ describe("FeeCalculator - Comprehensive Integration Tests with Real Data", () =>
       expect(actualData).toEqual(expectedData);
     });
 
-    it("should handle filtering to a distributor with no balance data", () => {
+    it("should throw error when filtering to a non-reward distributor", () => {
       // Setup test data
       fileManager.writeDistributors(testData.distributorsData);
 
@@ -207,15 +207,15 @@ describe("FeeCalculator - Comprehensive Integration Tests with Real Data", () =>
         }
       }
 
-      // Try to calculate fees for a distributor without balance data
-      // Note: This distributor exists but we didn't write balance data for it
-      const distributorWithoutData =
-        "0xdff90519a9DE6ad469D4f9839a9220C5D340B792";
-      calculator.calculateFees(distributorWithoutData);
+      // Try to calculate fees for a non-reward distributor
+      // Note: This distributor exists but has is_reward_distributor: false
+      const nonRewardDistributor = "0xdff90519a9DE6ad469D4f9839a9220C5D340B792";
 
-      // Should not create a fee report
-      const actualReport = fileManager.readFeeReport();
-      expect(actualReport).toBeUndefined();
+      expect(() => {
+        calculator.calculateFees(nonRewardDistributor);
+      }).toThrow(
+        "Distributor address 0xdff90519a9DE6ad469D4f9839a9220C5D340B792 is not a reward distributor and does not generate fee reports",
+      );
     });
   });
 

--- a/__tests__/units/fee-calculator.test.ts
+++ b/__tests__/units/fee-calculator.test.ts
@@ -93,6 +93,39 @@ describe("FeeCalculator Unit Tests", () => {
       jest.clearAllMocks();
     });
 
+    it("should throw error when specific non-reward distributor is requested", () => {
+      const mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0xNonRewardDistributor": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: false,
+            distributor_address: "0xNonRewardDistributor",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+
+      // Should throw when requesting a specific distributor that is not a reward distributor
+      expect(() => {
+        calculator.calculateFees("0xNonRewardDistributor");
+      }).toThrow(
+        "Distributor address 0xNonRewardDistributor is not a reward distributor and does not generate fee reports",
+      );
+    });
+
     it("skips distributors where is_reward_distributor is false", () => {
       const mockDistributorsData = {
         metadata: {

--- a/src/fee-calculator.ts
+++ b/src/fee-calculator.ts
@@ -34,6 +34,14 @@ export class FeeCalculator {
           `Distributor address ${distributorAddress} not found in distributor data`,
         );
       }
+      // Check if the specific distributor is a reward distributor
+      if (
+        !distributorsData.distributors[distributorAddress].is_reward_distributor
+      ) {
+        throw new Error(
+          `Distributor address ${distributorAddress} is not a reward distributor and does not generate fee reports`,
+        );
+      }
       distributorAddresses = [distributorAddress];
     } else if (distributorAddresses.length === 0) {
       // No distributor specified and no distributors exist - just return


### PR DESCRIPTION
## Summary
- Adds explicit error handling when `calculateFees()` is called with a specific distributor that is not a reward distributor
- Previously, the function would silently skip such distributors, making debugging difficult
- Now throws a clear error message explaining why fee reports cannot be generated

## Changes
- Added check in `fee-calculator.ts` to throw error for non-reward distributors when a specific distributor is requested
- Updated unit test to verify the new error behavior  
- Updated integration test that was expecting the old silent-skip behavior

## Test Plan
- [x] Unit test added to verify error is thrown for non-reward distributors
- [x] All existing unit tests pass (5 passed)
- [x] All existing integration tests pass (32 passed)
- [x] TypeScript checks pass
- [x] ESLint checks pass
- [x] Code formatting verified with Prettier

Fixes #244