### PR TITLE
Fix: Validate CLI arguments and reject unknown options

### DIFF
--- a/__tests__/units/cli-argument-parser.test.ts
+++ b/__tests__/units/cli-argument-parser.test.ts
@@ -118,4 +118,148 @@ describe("CLI Argument Parser", () => {
       expect(result["store-dir"]).toBe("/data/aep-fees");
     });
   });
+
+  describe("Unknown Arguments Validation", () => {
+    it("should reject single unknown argument", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--unknown",
+        "value",
+      ];
+
+      expect(() => parseArguments(args)).toThrow("Unknown argument: --unknown");
+    });
+
+    it("should reject misspelled argument", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--stroe-dir",
+        "/data/aep-fees",
+      ];
+
+      expect(() => parseArguments(args)).toThrow(
+        "Unknown argument: --stroe-dir",
+      );
+    });
+
+    it("should reject multiple unknown arguments", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--unknown1",
+        "value1",
+        "--unknown2",
+        "value2",
+      ];
+
+      expect(() => parseArguments(args)).toThrow(
+        /Unknown arguments: --unknown1, --unknown2/,
+      );
+    });
+
+    it("should include valid arguments list in error message", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--unknown",
+        "value",
+      ];
+
+      expect(() => parseArguments(args)).toThrow();
+
+      try {
+        parseArguments(args);
+      } catch (error) {
+        const message = (error as Error).message;
+        expect(message).toContain("Valid arguments:");
+        expect(message).toContain("--rpc-url");
+        expect(message).toContain("--start-date");
+        expect(message).toContain("--end-date");
+        expect(message).toContain("--store-dir");
+      }
+    });
+
+    it("should provide descriptions for valid arguments", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--unknown",
+        "value",
+      ];
+
+      expect(() => parseArguments(args)).toThrow();
+
+      try {
+        parseArguments(args);
+      } catch (error) {
+        const message = (error as Error).message;
+        expect(message).toContain(
+          "--rpc-url <url>      RPC endpoint URL (required)",
+        );
+        expect(message).toContain(
+          "--start-date <date>  Start date in YYYY-MM-DD format",
+        );
+        expect(message).toContain(
+          "--end-date <date>    End date in YYYY-MM-DD format",
+        );
+        expect(message).toContain(
+          "--store-dir <path>   Directory for storing data",
+        );
+      }
+    });
+
+    it("should accept all valid arguments without error", () => {
+      const validCombinations = [
+        ["--rpc-url", "https://archive-node.com/rpc"],
+        [
+          "--rpc-url",
+          "https://archive-node.com/rpc",
+          "--start-date",
+          "2024-01-01",
+        ],
+        [
+          "--rpc-url",
+          "https://archive-node.com/rpc",
+          "--end-date",
+          "2024-01-31",
+        ],
+        ["--rpc-url", "https://archive-node.com/rpc", "--store-dir", "/data"],
+        [
+          "--rpc-url",
+          "https://archive-node.com/rpc",
+          "--start-date",
+          "2024-01-01",
+          "--end-date",
+          "2024-01-31",
+          "--store-dir",
+          "/data",
+        ],
+      ];
+
+      validCombinations.forEach((args) => {
+        expect(() => parseArguments(args)).not.toThrow();
+      });
+    });
+
+    it("should handle boolean flags as unknown arguments", () => {
+      const args = ["--rpc-url", "https://archive-node.com/rpc", "--verbose"];
+
+      expect(() => parseArguments(args)).toThrow("Unknown argument: --verbose");
+    });
+
+    it("should handle arguments with special characters", () => {
+      const args = [
+        "--rpc-url",
+        "https://archive-node.com/rpc",
+        "--special-chars!@#",
+        "value",
+      ];
+
+      expect(() => parseArguments(args)).toThrow(
+        "Unknown argument: --special-chars!@#",
+      );
+    });
+  });
 });

--- a/src/parse-arguments.ts
+++ b/src/parse-arguments.ts
@@ -13,8 +13,32 @@ export interface ParsedArguments {
 const USAGE_MESSAGE =
   "Usage: aep --rpc-url <url> [--start-date <date>] [--end-date <date>] [--store-dir <path>]";
 
+const VALID_ARGUMENTS = ["rpc-url", "start-date", "end-date", "store-dir"];
+
+const ARGUMENT_DESCRIPTIONS = `Valid arguments:
+  --rpc-url <url>      RPC endpoint URL (required)
+  --start-date <date>  Start date in YYYY-MM-DD format
+  --end-date <date>    End date in YYYY-MM-DD format
+  --store-dir <path>   Directory for storing data`;
+
 export function parseArguments(args: string[]): ParsedArguments {
   const parsed = minimist(args) as ParsedArguments;
+
+  // Check for unknown arguments
+  const unknownArgs: string[] = [];
+  for (const key of Object.keys(parsed)) {
+    if (key !== "_" && !VALID_ARGUMENTS.includes(key)) {
+      unknownArgs.push(`--${key}`);
+    }
+  }
+
+  if (unknownArgs.length > 0) {
+    const errorMessage =
+      unknownArgs.length === 1
+        ? `Unknown argument: ${unknownArgs[0]}`
+        : `Unknown arguments: ${unknownArgs.join(", ")}`;
+    throw new Error(`${errorMessage}\n\n${ARGUMENT_DESCRIPTIONS}`);
+  }
 
   if (!parsed["rpc-url"]) {
     throw new Error(`--rpc-url is required\n\n${USAGE_MESSAGE}`);

--- a/src/parse-arguments.ts
+++ b/src/parse-arguments.ts
@@ -21,16 +21,10 @@ const ARGUMENT_DESCRIPTIONS = `Valid arguments:
   --end-date <date>    End date in YYYY-MM-DD format
   --store-dir <path>   Directory for storing data`;
 
-export function parseArguments(args: string[]): ParsedArguments {
-  const parsed = minimist(args) as ParsedArguments;
-
-  // Check for unknown arguments
-  const unknownArgs: string[] = [];
-  for (const key of Object.keys(parsed)) {
-    if (key !== "_" && !VALID_ARGUMENTS.includes(key)) {
-      unknownArgs.push(`--${key}`);
-    }
-  }
+function validateUnknownArguments(parsed: ParsedArguments): void {
+  const unknownArgs = Object.keys(parsed)
+    .filter((key) => key !== "_" && !VALID_ARGUMENTS.includes(key))
+    .map((key) => `--${key}`);
 
   if (unknownArgs.length > 0) {
     const errorMessage =
@@ -39,13 +33,20 @@ export function parseArguments(args: string[]): ParsedArguments {
         : `Unknown arguments: ${unknownArgs.join(", ")}`;
     throw new Error(`${errorMessage}\n\n${ARGUMENT_DESCRIPTIONS}`);
   }
+}
 
+function validateRequiredArguments(parsed: ParsedArguments): void {
   if (!parsed["rpc-url"]) {
     throw new Error(`--rpc-url is required\n\n${USAGE_MESSAGE}`);
   }
+}
 
-  // Validate the RPC URL format
-  validateRpcUrl(parsed["rpc-url"]);
+export function parseArguments(args: string[]): ParsedArguments {
+  const parsed = minimist(args) as ParsedArguments;
+
+  validateUnknownArguments(parsed);
+  validateRequiredArguments(parsed);
+  validateRpcUrl(parsed["rpc-url"]!);
 
   return parsed;
 }


### PR DESCRIPTION
## Summary
- Added validation to reject unknown/misspelled CLI arguments
- Shows clear error message listing the unknown arguments
- Displays list of valid arguments with descriptions to help users
- This is a **BREAKING CHANGE**: Scripts using typos or unknown arguments will now fail

## Implementation Details
Following TDD approach:
1. **RED**: Added comprehensive tests for argument validation
2. **GREEN**: Implemented minimal validation logic
3. **REFACTOR**: Extracted validation functions for better organization

## Example
Before (silent failure):
```bash
$ node dist/src/cli.js --rpc-url http://example.com --stroe-dir ./data
# Runs with default store directory, ignoring the typo
```

After (clear error):
```bash
$ node dist/src/cli.js --rpc-url http://example.com --stroe-dir ./data
Error: Unknown argument: --stroe-dir

Valid arguments:
  --rpc-url <url>      RPC endpoint URL (required)
  --start-date <date>  Start date in YYYY-MM-DD format
  --end-date <date>    End date in YYYY-MM-DD format
  --store-dir <path>   Directory for storing data
```

## Test Plan
- [x] All existing tests pass
- [x] New tests verify argument validation behavior
- [x] Manual testing with various argument combinations

Fixes #254