### PR TITLE
Fix: Remove console logs for non-reward distributor addresses

### DIFF
--- a/__tests__/units/core/fee-calculation/balance-fetcher.test.ts
+++ b/__tests__/units/core/fee-calculation/balance-fetcher.test.ts
@@ -925,6 +925,90 @@ describe("BalanceFetcher", () => {
       );
     });
 
+    it("only logs progress for reward distributors and logs skip message for non-reward distributors", async () => {
+      const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0xNonReward1": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x1111111111111111111111111111111111111111111111111111111111111111",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: false,
+            distributor_address: "0xNonReward1",
+          },
+          "0xRewardDistributor": {
+            type: DistributorType.L2_BASE_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x2222222222222222222222222222222222222222222222222222222222222222",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0xRewardDistributor",
+          },
+          "0xNonReward2": {
+            type: DistributorType.L1_BASE_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x3333333333333333333333333333333333333333333333333333333333333333",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: false,
+            distributor_address: "0xNonReward2",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances();
+
+      // Should not log progress for non-reward distributors
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Fetching balances for distributor 1/3: 0xNonReward1",
+        ),
+      );
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Fetching balances for distributor 3/3: 0xNonReward2",
+        ),
+      );
+
+      // Should log skip message for non-reward distributors
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Skipping distributor 0xNonReward1: not a reward distributor",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Skipping distributor 0xNonReward2: not a reward distributor",
+      );
+
+      // Should log progress for reward distributors with correct counter
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Fetching balances for distributor 1/1: 0xRewardDistributor",
+      );
+
+      consoleLogSpy.mockRestore();
+    });
+
     it("processes distributors where is_reward_distributor is true", async () => {
       mockDistributorsData = {
         metadata: {

--- a/__tests__/units/core/fee-calculation/recipient-recieved-scanner.test.ts
+++ b/__tests__/units/core/fee-calculation/recipient-recieved-scanner.test.ts
@@ -2111,6 +2111,89 @@ describe("RecipientRecievedScanner", () => {
       expect(mockProvider.getLogs).toHaveBeenCalledTimes(3);
     });
 
+    it("only logs progress for reward distributors and logs skip message for non-reward distributors", async () => {
+      const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0xNonReward1": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x1111111111111111111111111111111111111111111111111111111111111111",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: false,
+            distributor_address: "0xNonReward1",
+          },
+          "0xRewardDistributor": {
+            type: DistributorType.L2_BASE_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x2222222222222222222222222222222222222222222222222222222222222222",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0xRewardDistributor",
+          },
+          "0xNonReward2": {
+            type: DistributorType.L1_BASE_FEE,
+            block: 152,
+            date: "2022-07-12",
+            tx_hash:
+              "0x3333333333333333333333333333333333333333333333333333333333333333",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: false,
+            distributor_address: "0xNonReward2",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readRecipientRecievedEvents.mockReturnValue(undefined);
+
+      await scanner.scan();
+
+      // Should not log progress for non-reward distributors
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Scanning events for distributor 1/3: 0xNonReward1",
+        ),
+      );
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Scanning events for distributor 3/3: 0xNonReward2",
+        ),
+      );
+
+      // Should log skip message for non-reward distributors
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Skipping distributor 0xNonReward1: not a reward distributor",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Skipping distributor 0xNonReward2: not a reward distributor",
+      );
+
+      // Should log progress for reward distributors with correct counter
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Scanning events for distributor 1/1: 0xRewardDistributor",
+      );
+
+      consoleLogSpy.mockRestore();
+    });
+
     it("processes distributors where is_reward_distributor is true", async () => {
       mockDistributorsData = {
         metadata: {

--- a/src/core/fee-calculation/balance-fetcher.ts
+++ b/src/core/fee-calculation/balance-fetcher.ts
@@ -118,15 +118,27 @@ export class BalanceFetcher {
       [];
 
     const distributorEntries = Object.entries(distributorsToProcess);
-    let distributorIndex = 0;
+
+    // Count only reward distributors for accurate progress tracking
+    const rewardDistributors = distributorEntries.filter(
+      ([, info]) => info && info.is_reward_distributor,
+    );
+    let rewardDistributorIndex = 0;
 
     for (const [address, distributorInfo] of distributorEntries) {
-      distributorIndex++;
-      console.log(
-        `Fetching balances for distributor ${distributorIndex}/${distributorEntries.length}: ${address}`,
-      );
       if (!distributorInfo) continue;
-      if (!distributorInfo.is_reward_distributor) continue;
+
+      if (!distributorInfo.is_reward_distributor) {
+        console.log(
+          `Skipping distributor ${address}: not a reward distributor`,
+        );
+        continue;
+      }
+
+      rewardDistributorIndex++;
+      console.log(
+        `Fetching balances for distributor ${rewardDistributorIndex}/${rewardDistributors.length}: ${address}`,
+      );
 
       const creationDate = distributorInfo.date;
       const creationBlock = distributorInfo.block;

--- a/src/core/fee-calculation/recipient-recieved-scanner.ts
+++ b/src/core/fee-calculation/recipient-recieved-scanner.ts
@@ -128,16 +128,28 @@ export class RecipientRecievedScanner {
       : distributorsData.distributors;
 
     const distributorEntries = Object.entries(distributorsToProcess);
-    let distributorIndex = 0;
+
+    // Count only reward distributors for accurate progress tracking
+    const rewardDistributors = distributorEntries.filter(
+      ([, info]) => info && info.is_reward_distributor,
+    );
+    let rewardDistributorIndex = 0;
 
     // Process distributors
     for (const [address, distributorInfo] of distributorEntries) {
-      distributorIndex++;
-      console.log(
-        `Scanning events for distributor ${distributorIndex}/${distributorEntries.length}: ${address}`,
-      );
       if (!distributorInfo) continue;
-      if (!distributorInfo.is_reward_distributor) continue;
+
+      if (!distributorInfo.is_reward_distributor) {
+        console.log(
+          `Skipping distributor ${address}: not a reward distributor`,
+        );
+        continue;
+      }
+
+      rewardDistributorIndex++;
+      console.log(
+        `Scanning events for distributor ${rewardDistributorIndex}/${rewardDistributors.length}: ${address}`,
+      );
 
       await this.processDistributor(
         address,


### PR DESCRIPTION
## Summary
- Move progress logging after reward distributor check
- Add log message when skipping non-reward distributors  
- Update progress counter to only count reward distributors

## Test plan
- [x] Add tests to verify console logs only appear for reward distributors
- [x] Add tests to verify skip messages appear for non-reward distributors
- [x] Add tests to verify progress counter only counts reward distributors
- [x] All tests pass (604 tests passing)
- [x] Lint and typecheck pass

Fixes #256