### PR TITLE
fix: calculate default end date using safe block offset

### DIFF
--- a/__tests__/units/constants/index.test.ts
+++ b/__tests__/units/constants/index.test.ts
@@ -1,0 +1,17 @@
+import { SAFE_BLOCK_OFFSET } from "../../../src/constants";
+
+describe("Constants", () => {
+  describe("SAFE_BLOCK_OFFSET", () => {
+    it("should have correct value of 100", () => {
+      expect(SAFE_BLOCK_OFFSET).toBe(100);
+    });
+
+    it("should be a number", () => {
+      expect(typeof SAFE_BLOCK_OFFSET).toBe("number");
+    });
+
+    it("should be positive", () => {
+      expect(SAFE_BLOCK_OFFSET).toBeGreaterThan(0);
+    });
+  });
+});

--- a/__tests__/units/core/block-processing/block-finder.test.ts
+++ b/__tests__/units/core/block-processing/block-finder.test.ts
@@ -131,7 +131,7 @@ describe("BlockFinder - findBlocksForDateRange", () => {
       );
     }, 30000);
 
-    it("should skip dates that are too recent (less than 1000 blocks old)", async () => {
+    it("should skip dates that are too recent (less than SAFE_BLOCK_OFFSET blocks old)", async () => {
       const recentDate = new Date();
 
       jest.spyOn(provider, "getBlockNumber").mockImplementation(async () => {
@@ -278,6 +278,32 @@ describe("BlockFinder - findBlocksForDateRange", () => {
         blockFinder.findBlocksForDateRange(startDate, endDate),
       ).rejects.toThrow(
         /All blocks in range are after midnight|Unable to find block|before the target date/,
+      );
+    });
+  });
+
+  describe("getSafeCurrentBlock", () => {
+    it("should use SAFE_BLOCK_OFFSET from constants", async () => {
+      const { SAFE_BLOCK_OFFSET } = require("../../../../src/constants");
+
+      const currentBlockNumber = 5000;
+      jest
+        .spyOn(provider, "getBlockNumber")
+        .mockResolvedValue(currentBlockNumber);
+
+      const safeBlock = await blockFinder.getSafeCurrentBlock();
+
+      expect(safeBlock).toBe(currentBlockNumber - SAFE_BLOCK_OFFSET);
+      expect(SAFE_BLOCK_OFFSET).toBe(100);
+    });
+
+    it("should handle RPC errors when getting current block", async () => {
+      jest
+        .spyOn(provider, "getBlockNumber")
+        .mockRejectedValue(new Error("RPC error"));
+
+      await expect(blockFinder.getSafeCurrentBlock()).rejects.toThrow(
+        "Failed to get current block number",
       );
     });
   });

--- a/__tests__/units/core/block-processing/helpers.test.ts
+++ b/__tests__/units/core/block-processing/helpers.test.ts
@@ -127,11 +127,12 @@ describe("BlockFinder - Helper Functions", () => {
   });
 
   describe("getSafeCurrentBlock", () => {
-    it("should return current block number minus 1000", async () => {
+    it("should return current block number minus SAFE_BLOCK_OFFSET", async () => {
+      const { SAFE_BLOCK_OFFSET } = require("../../../../src/constants");
       const safeBlock = await blockFinder.getSafeCurrentBlock();
       const currentBlock = await provider.getBlockNumber();
 
-      expect(safeBlock).toBe(currentBlock - 1000);
+      expect(safeBlock).toBe(currentBlock - SAFE_BLOCK_OFFSET);
     });
 
     it("should throw error when unable to get current block", async () => {

--- a/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
+++ b/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
@@ -53,6 +53,7 @@ describe("orchestrator", () => {
 
     mockProvider = {
       getBlock: jest.fn(),
+      getBlockNumber: jest.fn(),
     } as unknown as jest.Mocked<ethers.Provider>;
 
     // Mock constructors
@@ -190,38 +191,65 @@ describe("orchestrator", () => {
       );
     });
 
-    it("should use block 1 timestamp and yesterday when no dates provided", async () => {
+    it("should use block 1 timestamp and safe block timestamp when no dates provided", async () => {
       const configWithoutDates: Configuration = {
         storeDirectory: "/test/store",
         rpcUrl: "https://test-rpc.example.com",
       };
 
+      // Mock current block number
+      const currentBlockNumber = 5000;
+      mockProvider.getBlockNumber.mockResolvedValue(currentBlockNumber);
+
       // Mock block 1 with a timestamp (July 12, 2022 UTC)
       const block1Timestamp = Math.floor(
         new Date("2022-07-12T00:00:00Z").getTime() / 1000,
       );
-      mockProvider.getBlock.mockResolvedValue({
-        timestamp: block1Timestamp,
-      } as unknown as ethers.Block);
+
+      // Mock safe block timestamp (June 29, 2025 UTC)
+      const safeBlockTimestamp = Math.floor(
+        new Date("2025-06-29T12:30:45Z").getTime() / 1000,
+      );
+
+      mockProvider.getBlock.mockImplementation(async (blockNumber) => {
+        if (blockNumber === 1) {
+          return {
+            timestamp: block1Timestamp,
+          } as unknown as ethers.Block;
+        } else if (blockNumber === currentBlockNumber - 100) {
+          // SAFE_BLOCK_OFFSET
+          return {
+            timestamp: safeBlockTimestamp,
+          } as unknown as ethers.Block;
+        }
+        return null;
+      });
 
       const chainStartDate = new Date(block1Timestamp * 1000);
       chainStartDate.setUTCHours(0, 0, 0, 0);
 
-      const yesterday = new Date();
-      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-      yesterday.setUTCHours(0, 0, 0, 0);
+      // Expected end date is one day before safe block timestamp
+      const expectedEndDate = new Date(safeBlockTimestamp * 1000);
+      expectedEndDate.setUTCDate(expectedEndDate.getUTCDate() - 1);
+      expectedEndDate.setUTCHours(0, 0, 0, 0);
 
       await orchestrate(configWithoutDates);
 
       // Verify that block 1 was fetched
       expect(mockProvider.getBlock).toHaveBeenCalledWith(1);
+      // Verify that safe block was fetched
+      expect(mockProvider.getBlock).toHaveBeenCalledWith(
+        currentBlockNumber - 100,
+      );
+      // Verify that current block number was fetched
+      expect(mockProvider.getBlockNumber).toHaveBeenCalled();
 
       const callArgs = mockBlockFinder.findBlocksForDateRange.mock.calls[0];
       expect(callArgs).toBeDefined();
       const [startDate, endDate] = callArgs!;
 
       expect(startDate.toISOString()).toBe(chainStartDate.toISOString());
-      expect(endDate.toISOString()).toBe(yesterday.toISOString());
+      expect(endDate.toISOString()).toBe(expectedEndDate.toISOString());
     });
 
     it("should throw error when block 1 cannot be fetched", async () => {
@@ -230,8 +258,21 @@ describe("orchestrator", () => {
         rpcUrl: "https://test-rpc.example.com",
       };
 
-      // Mock getBlock to return null
-      mockProvider.getBlock.mockResolvedValue(null);
+      // Mock getBlockNumber for the end date calculation
+      mockProvider.getBlockNumber.mockResolvedValue(5000);
+
+      // Mock getBlock to return null for block 1, but valid for safe block
+      mockProvider.getBlock.mockImplementation(async (blockNumber) => {
+        if (blockNumber === 1) {
+          return null;
+        } else if (blockNumber === 4900) {
+          // Safe block
+          return {
+            timestamp: Math.floor(Date.now() / 1000),
+          } as unknown as ethers.Block;
+        }
+        return null;
+      });
 
       await expect(orchestrate(configWithoutDates)).rejects.toThrow(
         "Failed to fetch block 1 from provider",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,6 +19,9 @@ export const CHAIN_IDS = {
   ARBITRUM_NOVA: 42170,
 } as const;
 
+// Block processing constants
+export const SAFE_BLOCK_OFFSET = 100;
+
 // Directory constants
 export const STORE_DIR = "store";
 export const DISTRIBUTORS_DIR = "distributors";

--- a/src/core/block-processing/block-finder.ts
+++ b/src/core/block-processing/block-finder.ts
@@ -7,8 +7,7 @@ import {
   BlockFinderError,
 } from "../../types";
 import { withRetry } from "../../utils/retry";
-
-const FINALITY_BLOCKS = 1000;
+import { SAFE_BLOCK_OFFSET } from "../../constants";
 const MILLISECONDS_PER_SECOND = 1000;
 const MINIMUM_VALID_BLOCK = 1;
 const RETRY_CONFIG = {
@@ -334,7 +333,7 @@ export class BlockFinder {
           operationName: "getBlockNumber",
         },
       );
-      return currentBlock - FINALITY_BLOCKS;
+      return currentBlock - SAFE_BLOCK_OFFSET;
     } catch (error) {
       const rpcError = new RPCError(
         `Failed to get current block number after ${RETRY_CONFIG.maxRetries} retries`,

--- a/src/infrastructure/orchestration/orchestrator.ts
+++ b/src/infrastructure/orchestration/orchestrator.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { Configuration } from "../../types";
+import { SAFE_BLOCK_OFFSET } from "../../constants";
 import { FileManager } from "../storage/file-manager";
 import { BlockFinder } from "../../core/block-processing/block-finder";
 import { DistributorDetector } from "../../core/distributor-detection/distributor-detector";
@@ -29,10 +30,32 @@ async function parseDateRange(
   startDate: Date;
   endDate: Date;
 }> {
-  // Default to yesterday for end date (since we can only process complete days)
-  const yesterday = new Date();
-  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-  yesterday.setUTCHours(0, 0, 0, 0);
+  // Calculate end date from safe block timestamp
+  let endDate: Date;
+  if (config.endDate) {
+    endDate = new Date(config.endDate);
+    if (isNaN(endDate.getTime())) {
+      throw new Error("Invalid end date format");
+    }
+  } else {
+    // Get current block number
+    const currentBlockNumber = await provider.getBlockNumber();
+    const safeBlockNumber = currentBlockNumber - SAFE_BLOCK_OFFSET;
+
+    // Get safe block timestamp
+    const safeBlock = await provider.getBlock(safeBlockNumber);
+    if (!safeBlock) {
+      throw new Error(`Unable to fetch block ${safeBlockNumber}`);
+    }
+
+    // Calculate date from safe block timestamp
+    const safeBlockDate = new Date(safeBlock.timestamp * 1000);
+
+    // Set end date to one day before safe block date
+    endDate = new Date(safeBlockDate);
+    endDate.setUTCDate(endDate.getUTCDate() - 1);
+    endDate.setUTCHours(0, 0, 0, 0);
+  }
 
   // Determine start date
   let startDate: Date;
@@ -49,11 +72,6 @@ async function parseDateRange(
     }
     startDate = new Date(block1.timestamp * 1000);
     startDate.setUTCHours(0, 0, 0, 0);
-  }
-
-  const endDate = config.endDate ? new Date(config.endDate) : yesterday;
-  if (config.endDate && isNaN(endDate.getTime())) {
-    throw new Error("Invalid end date format");
   }
 
   // Validate date range


### PR DESCRIPTION
## Summary
- Add shared SAFE_BLOCK_OFFSET constant (100) to replace FINALITY_BLOCKS (1000)
- Update block-finder to use the shared constant 
- Calculate default end date from safe block timestamp instead of yesterday
- Ensure only finalized blocks are processed across all chain environments

## Test plan
- [x] Added tests for new SAFE_BLOCK_OFFSET constant
- [x] Updated existing tests to use SAFE_BLOCK_OFFSET instead of hardcoded 1000
- [x] Added test for orchestrator calculating end date from safe block timestamp
- [x] All existing tests pass
- [x] Linter and typecheck pass

## Breaking Changes
⚠️ **BREAKING CHANGE**: Reduced safe block offset from 1000 to 100 blocks

This change ensures that the CLI only processes finalized blocks by calculating the end date based on the current block minus a safe offset, preventing potential reorg issues across all chain environments.

Fixes #258