### PR TITLE
Fix: Constrain components to block range from block numbers store

### DIFF
--- a/__tests__/units/core/fee-calculation/balance-fetcher.test.ts
+++ b/__tests__/units/core/fee-calculation/balance-fetcher.test.ts
@@ -54,8 +54,8 @@ describe("BalanceFetcher", () => {
       expect(typeof fetcher.fetchBalances).toBe("function");
     });
 
-    it("accepts optional distributorAddress parameter", () => {
-      expect(fetcher.fetchBalances.length).toBeLessThanOrEqual(1);
+    it("accepts optional distributorAddress and endDate parameters", () => {
+      expect(fetcher.fetchBalances.length).toBeLessThanOrEqual(2);
     });
 
     it("returns a Promise", () => {
@@ -320,6 +320,188 @@ describe("BalanceFetcher", () => {
 
       // Should not fetch any balances for future distributors
       expect(mockProvider.getBalance).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchBalances - endDate parameter", () => {
+    let fetcher: BalanceFetcher;
+    let mockDistributorsData: DistributorsData;
+    let mockBlockNumberData: BlockNumberData;
+
+    beforeEach(() => {
+      mockFileManager = {
+        readDistributors: jest.fn(),
+        readBlockNumbers: jest.fn(),
+        readDistributorBalances: jest.fn(),
+        writeDistributorBalances: jest.fn(),
+        getMaxDate: jest.fn(),
+        validateDateFormat: jest.fn(),
+      } as unknown as jest.Mocked<FileManager>;
+      mockProvider = {
+        getBalance: jest.fn(),
+        getNetwork: jest
+          .fn()
+          .mockResolvedValue({ chainId: 42170n } as unknown as ethers.Network),
+      } as unknown as jest.Mocked<ethers.Provider>;
+      fetcher = new BalanceFetcher(mockFileManager, mockProvider);
+
+      mockBlockNumberData = {
+        metadata: {
+          chain_id: 42170,
+        },
+        blocks: {
+          "2022-07-11": 120,
+          "2022-07-12": 155,
+          "2022-07-13": 189,
+          "2022-08-07": 654,
+          "2022-08-08": 672,
+          "2022-08-09": 3584,
+          "2023-03-15": 3141957,
+          "2023-03-16": 3166694,
+          "2023-03-17": 3187362,
+        },
+      };
+
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0xdff90519a9DE6ad469D4f9839a9220C5D340B792": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 672,
+            date: "2022-08-08",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0xdff90519a9DE6ad469D4f9839a9220C5D340B792",
+          },
+        },
+      };
+    });
+
+    it("accepts endDate as second parameter", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await expect(
+        fetcher.fetchBalances(undefined, "2022-08-09"),
+      ).resolves.not.toThrow();
+    });
+
+    it("only processes blocks up to endDate when provided", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances(undefined, "2022-08-09");
+
+      // Should only fetch balances for dates: 2022-08-08 and 2022-08-09
+      expect(mockProvider.getBalance).toHaveBeenCalledTimes(2);
+      expect(mockProvider.getBalance).toHaveBeenCalledWith(
+        "0xdff90519a9DE6ad469D4f9839a9220C5D340B792",
+        672,
+      );
+      expect(mockProvider.getBalance).toHaveBeenCalledWith(
+        "0xdff90519a9DE6ad469D4f9839a9220C5D340B792",
+        3584,
+      );
+    });
+
+    it("validates endDate format", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.validateDateFormat.mockImplementation((date: string) => {
+        if (date === "invalid-date") {
+          throw new Error("Invalid date format: invalid-date");
+        }
+      });
+
+      await expect(
+        fetcher.fetchBalances(undefined, "invalid-date"),
+      ).rejects.toThrow("Invalid date format: invalid-date");
+    });
+
+    it("validates endDate is a valid calendar date", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.validateDateFormat.mockImplementation((date: string) => {
+        if (date === "2022-13-01") {
+          throw new Error("Invalid calendar date: 2022-13-01");
+        }
+      });
+
+      await expect(
+        fetcher.fetchBalances(undefined, "2022-13-01"),
+      ).rejects.toThrow("Invalid calendar date: 2022-13-01");
+    });
+
+    it("throws error if endDate is not in block numbers data", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+
+      await expect(
+        fetcher.fetchBalances(undefined, "2022-10-01"),
+      ).rejects.toThrow("No block number found for end date: 2022-10-01");
+    });
+
+    it("filters both start and end dates correctly", async () => {
+      // Add a distributor with earlier creation date
+      const multipleDistributorsData = {
+        ...mockDistributorsData,
+        distributors: {
+          ...mockDistributorsData.distributors,
+          "0x1111111111111111111111111111111111111111": {
+            type: DistributorType.L2_BASE_FEE,
+            block: 120,
+            date: "2022-07-11",
+            tx_hash: "0x1111",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x1111111111111111111111111111111111111111",
+          },
+        },
+      };
+
+      mockFileManager.readDistributors.mockReturnValue(
+        multipleDistributorsData,
+      );
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumberData);
+      mockFileManager.readDistributorBalances.mockReturnValue(undefined);
+      mockProvider.getBalance.mockResolvedValue(BigInt("1000000000000000000"));
+
+      await fetcher.fetchBalances(undefined, "2022-08-08");
+
+      // Fetches are done in chronological order across all distributors
+      const expectedCalls = [
+        ["0x1111111111111111111111111111111111111111", 120], // 2022-07-11
+        ["0x1111111111111111111111111111111111111111", 155], // 2022-07-12
+        ["0x1111111111111111111111111111111111111111", 189], // 2022-07-13
+        ["0x1111111111111111111111111111111111111111", 654], // 2022-08-07
+        ["0xdff90519a9DE6ad469D4f9839a9220C5D340B792", 672], // 2022-08-08 (distributor 2)
+        ["0x1111111111111111111111111111111111111111", 672], // 2022-08-08 (distributor 1)
+      ];
+
+      expect(mockProvider.getBalance).toHaveBeenCalledTimes(
+        expectedCalls.length,
+      );
+      expectedCalls.forEach(([address, block], index) => {
+        expect(mockProvider.getBalance).toHaveBeenNthCalledWith(
+          index + 1,
+          address,
+          block,
+        );
+      });
     });
   });
 

--- a/__tests__/units/core/fee-calculation/fee-calculator.test.ts
+++ b/__tests__/units/core/fee-calculation/fee-calculator.test.ts
@@ -11,6 +11,8 @@ describe("FeeCalculator Unit Tests", () => {
     mockFileManager = {
       readBlockNumbers: jest.fn(),
       writeBlockNumbers: jest.fn(),
+      getMinDate: jest.fn(),
+      getMaxDate: jest.fn(),
       readDistributors: jest.fn(),
       writeDistributors: jest.fn(),
       readDistributorBalances: jest.fn(),

--- a/__tests__/units/core/fee-calculation/recipient-recieved-scanner.test.ts
+++ b/__tests__/units/core/fee-calculation/recipient-recieved-scanner.test.ts
@@ -68,8 +68,8 @@ describe("RecipientRecievedScanner", () => {
       expect(typeof scanner.scan).toBe("function");
     });
 
-    it("accepts optional distributorAddress parameter", () => {
-      expect(scanner.scan.length).toBeLessThanOrEqual(1);
+    it("accepts optional distributorAddress and endDate parameters", () => {
+      expect(scanner.scan.length).toBeLessThanOrEqual(2);
     });
 
     it("returns a Promise", () => {
@@ -604,6 +604,171 @@ describe("RecipientRecievedScanner", () => {
 
       await expect(scanner.scan()).rejects.toThrow(
         "Cannot find date for block 999 for distributor 0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+      );
+    });
+  });
+
+  describe("scan - endDate parameter", () => {
+    let scanner: RecipientRecievedScanner;
+    let mockDistributorsData: DistributorsData;
+    let mockBlockNumbersData: BlockNumberData;
+
+    beforeEach(() => {
+      mockFileManager = {
+        readDistributors: jest.fn(),
+        readBlockNumbers: jest.fn(),
+        readRecipientRecievedEvents: jest.fn(),
+        writeRecipientRecievedEvents: jest.fn(),
+        validateDateFormat: jest.fn(),
+      } as unknown as jest.Mocked<FileManager>;
+      scanner = new RecipientRecievedScanner(mockProvider, mockFileManager);
+
+      mockDistributorsData = {
+        metadata: {
+          chain_id: 42170,
+          arbowner_address: "0x0000000000000000000000000000000000000070",
+          last_scanned_block: 1000,
+        },
+        distributors: {
+          "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB": {
+            type: DistributorType.L2_SURPLUS_FEE,
+            block: 152,
+            date: "2022-07-10",
+            tx_hash:
+              "0x6151c7f22d923b9a1ae3d0302b03e8cd2af70ee5792b26e10858d4de6b005fa9",
+            method: "0xfcdde2b4",
+            owner: "0x9C040726F2A657226Ed95712245DeE84b650A1b5",
+            event_data: "0x...",
+            is_reward_distributor: true,
+            distributor_address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          },
+        },
+      };
+
+      mockBlockNumbersData = {
+        metadata: { chain_id: 42170 },
+        blocks: {
+          "2022-07-10": 50,
+          "2022-07-11": 100,
+          "2022-07-12": 200,
+          "2022-07-13": 300,
+          "2022-07-14": 400,
+          "2022-07-15": 500,
+          "2022-07-16": 600,
+        },
+      };
+    });
+
+    it("accepts endDate as second parameter", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readRecipientRecievedEvents.mockReturnValue(undefined);
+
+      await expect(
+        scanner.scan(undefined, "2022-07-12"),
+      ).resolves.not.toThrow();
+    });
+
+    it("uses provided endDate instead of calculating yesterday", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readRecipientRecievedEvents.mockReturnValue(undefined);
+
+      // Spy on console.log to verify the date range
+      const consoleSpy = jest.spyOn(console, "log");
+
+      await scanner.scan(undefined, "2022-07-12");
+
+      // Should log scanning up to 2022-07-12, not yesterday (2022-07-14)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Scanning date range: 2022-07-10 to 2022-07-12",
+        ),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("validates endDate format", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.validateDateFormat.mockImplementation((date: string) => {
+        if (date === "invalid-date") {
+          throw new Error("Invalid date format: invalid-date");
+        }
+      });
+
+      await expect(scanner.scan(undefined, "invalid-date")).rejects.toThrow(
+        "Invalid date format: invalid-date",
+      );
+    });
+
+    it("validates endDate is a valid calendar date", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.validateDateFormat.mockImplementation((date: string) => {
+        if (date === "2022-13-01") {
+          throw new Error("Invalid calendar date: 2022-13-01");
+        }
+      });
+
+      await expect(scanner.scan(undefined, "2022-13-01")).rejects.toThrow(
+        "Invalid calendar date: 2022-13-01",
+      );
+    });
+
+    it("throws error if endDate is not in block numbers data", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+
+      await expect(scanner.scan(undefined, "2022-07-20")).rejects.toThrow(
+        "No block number found for end date: 2022-07-20",
+      );
+    });
+
+    it("correctly processes distributor with custom endDate", async () => {
+      mockFileManager.readDistributors.mockReturnValue(mockDistributorsData);
+      mockFileManager.readBlockNumbers.mockReturnValue(mockBlockNumbersData);
+      mockFileManager.readRecipientRecievedEvents.mockReturnValue(undefined);
+
+      // Mock getLogs to return some events
+      const mockEvents = [
+        {
+          blockNumber: 150,
+          blockHash: "0xdef456",
+          transactionHash: "0xabc123",
+          transactionIndex: 0,
+          removed: false,
+          index: 0,
+          address: "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+          topics: [
+            RECIPIENT_RECIEVED_EVENT_TOPIC,
+            ethers.zeroPadValue(
+              "0x1234567890123456789012345678901234567890",
+              32,
+            ),
+          ],
+          data: ethers.zeroPadValue("0x1000", 32),
+          provider: mockProvider,
+          toJSON: () => ({}),
+          getBlock: () => Promise.resolve({} as unknown),
+          getTransaction: () => Promise.resolve({} as unknown),
+          getTransactionReceipt: () => Promise.resolve({} as unknown),
+          removedEvent: () => Promise.resolve({} as unknown),
+        } as unknown as ethers.Log,
+      ];
+      mockProvider.getLogs.mockResolvedValue(mockEvents);
+
+      await scanner.scan(undefined, "2022-07-11");
+
+      // Verify writeRecipientRecievedEvents was called
+      expect(mockFileManager.writeRecipientRecievedEvents).toHaveBeenCalledWith(
+        "0x37daA99b1cAAE0c22670963e103a66CA2c5dB2dB",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            last_scanned_block: 100, // Should be the block for 2022-07-11
+          }),
+        }),
       );
     });
   });

--- a/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
+++ b/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
@@ -190,11 +190,14 @@ describe("orchestrator", () => {
       );
     });
 
-    it("should use block 1 timestamp and yesterday when no dates provided", async () => {
+    it("should use block 1 timestamp and block store max date when no dates provided", async () => {
       const configWithoutDates: Configuration = {
         storeDirectory: "/test/store",
         rpcUrl: "https://test-rpc.example.com",
       };
+
+      // Add getMaxDate method to mockFileManager
+      mockFileManager.getMaxDate = jest.fn().mockReturnValue("2024-01-15");
 
       // Mock block 1 with a timestamp (July 12, 2022 UTC)
       const block1Timestamp = Math.floor(
@@ -207,10 +210,6 @@ describe("orchestrator", () => {
       const chainStartDate = new Date(block1Timestamp * 1000);
       chainStartDate.setUTCHours(0, 0, 0, 0);
 
-      const yesterday = new Date();
-      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-      yesterday.setUTCHours(0, 0, 0, 0);
-
       await orchestrate(configWithoutDates);
 
       // Verify that block 1 was fetched
@@ -221,7 +220,7 @@ describe("orchestrator", () => {
       const [startDate, endDate] = callArgs!;
 
       expect(startDate.toISOString()).toBe(chainStartDate.toISOString());
-      expect(endDate.toISOString()).toBe(yesterday.toISOString());
+      expect(endDate).toEqual(new Date("2024-01-15"));
     });
 
     it("should throw error when block 1 cannot be fetched", async () => {
@@ -333,16 +332,22 @@ describe("orchestrator", () => {
       );
     });
 
-    it("should call balanceFetcher without parameters", async () => {
+    it("should call balanceFetcher with endDate parameter", async () => {
       await orchestrate(configuration);
 
-      expect(mockBalanceFetcher.fetchBalances).toHaveBeenCalledWith();
+      expect(mockBalanceFetcher.fetchBalances).toHaveBeenCalledWith(
+        undefined,
+        "2024-01-31",
+      );
     });
 
-    it("should call recipientRecievedScanner without parameters", async () => {
+    it("should call recipientRecievedScanner with endDate parameter", async () => {
       await orchestrate(configuration);
 
-      expect(mockRecipientRecievedScanner.scan).toHaveBeenCalledWith();
+      expect(mockRecipientRecievedScanner.scan).toHaveBeenCalledWith(
+        undefined,
+        "2024-01-31",
+      );
     });
 
     it("should call feeCalculator without parameters", async () => {

--- a/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
+++ b/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
@@ -238,6 +238,70 @@ describe("orchestrator", () => {
       );
     });
 
+    it("should use block store max date instead of yesterday when no endDate provided", async () => {
+      const configWithoutDates: Configuration = {
+        storeDirectory: "/test/store",
+        rpcUrl: "https://test-rpc.example.com",
+      };
+
+      // Add getMaxDate method to mockFileManager
+      mockFileManager.getMaxDate = jest.fn().mockReturnValue("2024-01-15");
+
+      // Mock block 1 with a timestamp
+      const block1Timestamp = Math.floor(
+        new Date("2022-07-12T00:00:00Z").getTime() / 1000,
+      );
+      mockProvider.getBlock.mockResolvedValue({
+        timestamp: block1Timestamp,
+      } as unknown as ethers.Block);
+
+      await orchestrate(configWithoutDates);
+
+      // Verify getMaxDate was called
+      expect(mockFileManager.getMaxDate).toHaveBeenCalled();
+
+      // Verify that the block store date was used as end date
+      const callArgs = mockBlockFinder.findBlocksForDateRange.mock.calls[0];
+      const [, endDate] = callArgs!;
+      expect(endDate).toEqual(new Date("2024-01-15"));
+    });
+
+    it("should throw error when block store has no dates", async () => {
+      const configWithoutDates: Configuration = {
+        storeDirectory: "/test/store",
+        rpcUrl: "https://test-rpc.example.com",
+      };
+
+      // Add getMaxDate method that returns undefined
+      mockFileManager.getMaxDate = jest.fn().mockReturnValue(undefined);
+
+      // Mock block 1 with a timestamp (needed for start date)
+      const block1Timestamp = Math.floor(
+        new Date("2022-07-12T00:00:00Z").getTime() / 1000,
+      );
+      mockProvider.getBlock.mockResolvedValue({
+        timestamp: block1Timestamp,
+      } as unknown as ethers.Block);
+
+      await expect(orchestrate(configWithoutDates)).rejects.toThrow(
+        "No block data available in store",
+      );
+    });
+
+    it("should pass endDate to BalanceFetcher and RecipientRecievedScanner", async () => {
+      await orchestrate(configuration);
+
+      // Should pass endDate as formatted string to components
+      expect(mockBalanceFetcher.fetchBalances).toHaveBeenCalledWith(
+        undefined,
+        "2024-01-31",
+      );
+      expect(mockRecipientRecievedScanner.scan).toHaveBeenCalledWith(
+        undefined,
+        "2024-01-31",
+      );
+    });
+
     it("should use provided dates when specified", async () => {
       const customConfig: Configuration = {
         storeDirectory: "/test/store",

--- a/__tests__/units/infrastructure/storage/block-numbers.test.ts
+++ b/__tests__/units/infrastructure/storage/block-numbers.test.ts
@@ -191,4 +191,108 @@ describe("FileManager - Block Numbers", () => {
       );
     });
   });
+
+  describe("getMinDate()", () => {
+    it("should return undefined when block_numbers.json does not exist", () => {
+      const result = testContext.fileManager.getMinDate();
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when blocks object is empty", () => {
+      const testData = createBlockNumberData({
+        blocks: {},
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMinDate();
+      expect(result).toBeUndefined();
+    });
+
+    it("should return the earliest date when blocks contains multiple dates", () => {
+      const testData = createBlockNumberData({
+        blocks: {
+          "2024-01-17": 12367890,
+          "2024-01-15": 12345678,
+          "2024-01-16": 12356789,
+        },
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMinDate();
+      expect(result).toBe("2024-01-15");
+    });
+
+    it("should return the only date when blocks contains single date", () => {
+      const testData = createBlockNumberData({
+        blocks: {
+          "2024-01-20": 12345678,
+        },
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMinDate();
+      expect(result).toBe("2024-01-20");
+    });
+  });
+
+  describe("getMaxDate()", () => {
+    it("should return undefined when block_numbers.json does not exist", () => {
+      const result = testContext.fileManager.getMaxDate();
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when blocks object is empty", () => {
+      const testData = createBlockNumberData({
+        blocks: {},
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMaxDate();
+      expect(result).toBeUndefined();
+    });
+
+    it("should return the latest date when blocks contains multiple dates", () => {
+      const testData = createBlockNumberData({
+        blocks: {
+          "2024-01-17": 12367890,
+          "2024-01-15": 12345678,
+          "2024-01-16": 12356789,
+        },
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMaxDate();
+      expect(result).toBe("2024-01-17");
+    });
+
+    it("should return the only date when blocks contains single date", () => {
+      const testData = createBlockNumberData({
+        blocks: {
+          "2024-01-20": 12345678,
+        },
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const result = testContext.fileManager.getMaxDate();
+      expect(result).toBe("2024-01-20");
+    });
+
+    it("should handle dates spanning multiple years correctly", () => {
+      const testData = createBlockNumberData({
+        blocks: {
+          "2023-12-31": 11111111,
+          "2024-01-01": 22222222,
+          "2024-12-31": 33333333,
+          "2025-01-01": 44444444,
+        },
+      });
+      testContext.fileManager.writeBlockNumbers(testData);
+
+      const minDate = testContext.fileManager.getMinDate();
+      const maxDate = testContext.fileManager.getMaxDate();
+
+      expect(minDate).toBe("2023-12-31");
+      expect(maxDate).toBe("2025-01-01");
+    });
+  });
 });

--- a/__tests__/units/types.test.ts
+++ b/__tests__/units/types.test.ts
@@ -362,6 +362,8 @@ describe("Core Types", () => {
           blocks: {},
         }),
         writeBlockNumbers: () => {},
+        getMinDate: () => undefined,
+        getMaxDate: () => undefined,
         readDistributors: () => ({
           metadata: { chain_id: 42170, arbowner_address: "" },
           distributors: {},

--- a/src/core/fee-calculation/balance-fetcher.ts
+++ b/src/core/fee-calculation/balance-fetcher.ts
@@ -62,11 +62,13 @@ export class BalanceFetcher {
    * Uses incremental processing to only fetch balances for dates that haven't been fetched yet.
    *
    * @param distributorAddress - If provided, only fetch balances for this specific distributor
+   * @param endDate - Optional end date in YYYY-MM-DD format. If omitted, fetches all available dates
    * @returns Promise that resolves with collected decimal string balances by distributor and date, or empty record if no new balances to fetch
    * @throws Error on any failure
    */
   async fetchBalances(
     distributorAddress?: string,
+    endDate?: string,
   ): Promise<Record<string, Record<string, string>>> {
     // Validate distributorAddress parameter if provided
     if (
@@ -75,6 +77,12 @@ export class BalanceFetcher {
     ) {
       throw new Error(`Invalid Ethereum address: ${distributorAddress}`);
     }
+
+    // Validate endDate if provided
+    if (endDate !== undefined) {
+      this.fileManager.validateDateFormat(endDate);
+    }
+
     const distributorsData = this.fileManager.readDistributors();
 
     // Early return if no distributors data
@@ -97,6 +105,11 @@ export class BalanceFetcher {
     const blockNumbersData = this.fileManager.readBlockNumbers();
     if (!blockNumbersData) {
       return {};
+    }
+
+    // Verify endDate exists in block numbers data if provided
+    if (endDate !== undefined && !(endDate in blockNumbersData.blocks)) {
+      throw new Error(`No block number found for end date: ${endDate}`);
     }
 
     // Process distributors
@@ -136,9 +149,13 @@ export class BalanceFetcher {
         this.fileManager.readDistributorBalances(address);
       existingBalancesByDistributor[address] = existingBalances;
 
-      // Get all block numbers from creation date onward
+      // Get all block numbers from creation date onward, up to endDate if provided
       const endOfDayBlocks = Object.entries(blockNumbersData.blocks).filter(
-        ([date]) => date >= creationDate,
+        ([date]) => {
+          const afterCreation = date >= creationDate;
+          const beforeEnd = endDate === undefined || date <= endDate;
+          return afterCreation && beforeEnd;
+        },
       );
 
       // Skip future distributors (no applicable blocks to fetch)

--- a/src/core/fee-calculation/recipient-recieved-scanner.ts
+++ b/src/core/fee-calculation/recipient-recieved-scanner.ts
@@ -81,15 +81,21 @@ export class RecipientRecievedScanner {
    * Currently implements only address validation. Full implementation pending issue #173 and #174.
    *
    * @param distributorAddress - Optional distributor address. If provided, scans only that distributor. If omitted, scans all distributors
+   * @param endDate - Optional end date in YYYY-MM-DD format. If omitted, defaults to yesterday
    * @returns Promise that resolves when scanning is complete
-   * @throws Error if invalid Ethereum address provided
+   * @throws Error if invalid Ethereum address provided or invalid date format
    */
-  async scan(distributorAddress?: string): Promise<void> {
+  async scan(distributorAddress?: string, endDate?: string): Promise<void> {
     if (
       distributorAddress !== undefined &&
       !ethers.isAddress(distributorAddress)
     ) {
       throw new Error(`Invalid Ethereum address: ${distributorAddress}`);
+    }
+
+    // Validate endDate if provided
+    if (endDate !== undefined) {
+      this.fileManager.validateDateFormat(endDate);
     }
 
     const distributorsData = this.fileManager.readDistributors();
@@ -113,11 +119,21 @@ export class RecipientRecievedScanner {
       return;
     }
 
-    // Calculate yesterday's date
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = this.formatDate(yesterday);
+    // Determine end date
+    let endDateStr: string;
+    if (endDate !== undefined) {
+      endDateStr = endDate;
+      // Verify the date exists in block numbers data
+      if (!(endDateStr in blockNumbersData.blocks)) {
+        throw new Error(`No block number found for end date: ${endDateStr}`);
+      }
+    } else {
+      // Calculate yesterday's date
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+      endDateStr = this.formatDate(yesterday);
+    }
 
     // Process distributors
     const distributorsToProcess = distributorAddress
@@ -143,7 +159,7 @@ export class RecipientRecievedScanner {
         address,
         distributorInfo,
         blockNumbersData,
-        yesterdayStr,
+        endDateStr,
       );
     }
   }
@@ -195,17 +211,17 @@ export class RecipientRecievedScanner {
   }
 
   /**
-   * Processes a distributor day by day from last scanned date to yesterday.
+   * Processes a distributor day by day from last scanned date to end date.
    * @private
    */
   private async processDistributor(
     address: string,
     distributorInfo: DistributorInfo,
     blockNumbersData: BlockNumberData,
-    yesterdayStr: string,
+    endDateStr: string,
   ): Promise<void> {
     // Check if distributor is created in the future
-    if (distributorInfo.date > yesterdayStr) {
+    if (distributorInfo.date > endDateStr) {
       return;
     }
 
@@ -236,12 +252,12 @@ export class RecipientRecievedScanner {
       startDate = distributorInfo.date;
     }
 
-    // Skip if start date is after yesterday (all dates processed)
-    if (startDate > yesterdayStr) {
+    // Skip if start date is after end date (all dates processed)
+    if (startDate > endDateStr) {
       return;
     }
 
-    console.log(`Scanning date range: ${startDate} to ${yesterdayStr}`);
+    console.log(`Scanning date range: ${startDate} to ${endDateStr}`);
 
     // Get chain ID from distributors data
     const distributorsData = this.fileManager.readDistributors();
@@ -252,7 +268,7 @@ export class RecipientRecievedScanner {
 
     // Process one day at a time
     const currentDate = new Date(startDate);
-    const endDate = new Date(yesterdayStr);
+    const endDate = new Date(endDateStr);
     let lastProcessedBlock = 0;
 
     while (currentDate <= endDate) {

--- a/src/infrastructure/orchestration/orchestrator.ts
+++ b/src/infrastructure/orchestration/orchestrator.ts
@@ -16,7 +16,11 @@ export async function orchestrate(config: Configuration): Promise<void> {
   fileManager.ensureStoreDirectory();
 
   // Parse date range
-  const { startDate, endDate } = await parseDateRange(config, provider);
+  const { startDate, endDate } = await parseDateRange(
+    config,
+    provider,
+    fileManager,
+  );
 
   // Execute pipeline components sequentially
   await executePipeline(fileManager, provider, startDate, endDate);
@@ -25,15 +29,11 @@ export async function orchestrate(config: Configuration): Promise<void> {
 async function parseDateRange(
   config: Configuration,
   provider: ethers.Provider,
+  fileManager: FileManager,
 ): Promise<{
   startDate: Date;
   endDate: Date;
 }> {
-  // Default to yesterday for end date (since we can only process complete days)
-  const yesterday = new Date();
-  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-  yesterday.setUTCHours(0, 0, 0, 0);
-
   // Determine start date
   let startDate: Date;
   if (config.startDate) {
@@ -51,9 +51,20 @@ async function parseDateRange(
     startDate.setUTCHours(0, 0, 0, 0);
   }
 
-  const endDate = config.endDate ? new Date(config.endDate) : yesterday;
-  if (config.endDate && isNaN(endDate.getTime())) {
-    throw new Error("Invalid end date format");
+  // Determine end date
+  let endDate: Date;
+  if (config.endDate) {
+    endDate = new Date(config.endDate);
+    if (isNaN(endDate.getTime())) {
+      throw new Error("Invalid end date format");
+    }
+  } else {
+    // Use max date from block store
+    const maxDateStr = fileManager.getMaxDate();
+    if (!maxDateStr) {
+      throw new Error("No block data available in store");
+    }
+    endDate = new Date(maxDateStr);
   }
 
   // Validate date range
@@ -70,6 +81,9 @@ async function executePipeline(
   startDate: Date,
   endDate: Date,
 ): Promise<void> {
+  // Format endDate as YYYY-MM-DD string
+  const endDateStr = endDate.toISOString().split("T")[0];
+
   // 1. Find blocks for date range
   console.log("Starting Block Finder...");
   const blockFinder = new BlockFinder(fileManager, provider);
@@ -83,7 +97,7 @@ async function executePipeline(
   // 3. Fetch distributor balances
   console.log("Starting Balance Fetcher...");
   const balanceFetcher = new BalanceFetcher(fileManager, provider);
-  await balanceFetcher.fetchBalances();
+  await balanceFetcher.fetchBalances(undefined, endDateStr);
 
   // 4. Scan for recipient received events
   console.log("Starting Recipient Received Scanner...");
@@ -91,7 +105,7 @@ async function executePipeline(
     provider,
     fileManager,
   );
-  await recipientRecievedScanner.scan();
+  await recipientRecievedScanner.scan(undefined, endDateStr);
 
   // 5. Calculate fees
   console.log("Starting Fee Calculator...");

--- a/src/infrastructure/storage/file-manager.ts
+++ b/src/infrastructure/storage/file-manager.ts
@@ -68,6 +68,34 @@ export class FileManager implements FileManagerInterface {
     );
   }
 
+  getMinDate(): DateString | undefined {
+    const blockNumbersData = this.readBlockNumbers();
+    if (
+      !blockNumbersData ||
+      Object.keys(blockNumbersData.blocks).length === 0
+    ) {
+      return undefined;
+    }
+
+    const dates = Object.keys(blockNumbersData.blocks);
+    dates.sort();
+    return dates[0] as DateString;
+  }
+
+  getMaxDate(): DateString | undefined {
+    const blockNumbersData = this.readBlockNumbers();
+    if (
+      !blockNumbersData ||
+      Object.keys(blockNumbersData.blocks).length === 0
+    ) {
+      return undefined;
+    }
+
+    const dates = Object.keys(blockNumbersData.blocks);
+    dates.sort();
+    return dates[dates.length - 1] as DateString;
+  }
+
   readDistributors(): DistributorsData | undefined {
     return this.readJsonFileOrUndefined(
       path.join(this.storeDirectory, DISTRIBUTORS_FILE),

--- a/src/infrastructure/storage/file-manager.ts
+++ b/src/infrastructure/storage/file-manager.ts
@@ -69,31 +69,25 @@ export class FileManager implements FileManagerInterface {
   }
 
   getMinDate(): DateString | undefined {
-    const blockNumbersData = this.readBlockNumbers();
-    if (
-      !blockNumbersData ||
-      Object.keys(blockNumbersData.blocks).length === 0
-    ) {
-      return undefined;
-    }
-
-    const dates = Object.keys(blockNumbersData.blocks);
-    dates.sort();
-    return dates[0] as DateString;
+    const sortedDates = this.getSortedBlockDates();
+    return sortedDates.length > 0 ? (sortedDates[0] as DateString) : undefined;
   }
 
   getMaxDate(): DateString | undefined {
+    const sortedDates = this.getSortedBlockDates();
+    return sortedDates.length > 0
+      ? (sortedDates[sortedDates.length - 1] as DateString)
+      : undefined;
+  }
+
+  private getSortedBlockDates(): string[] {
     const blockNumbersData = this.readBlockNumbers();
-    if (
-      !blockNumbersData ||
-      Object.keys(blockNumbersData.blocks).length === 0
-    ) {
-      return undefined;
+    if (!blockNumbersData) {
+      return [];
     }
 
     const dates = Object.keys(blockNumbersData.blocks);
-    dates.sort();
-    return dates[dates.length - 1] as DateString;
+    return dates.sort();
   }
 
   readDistributors(): DistributorsData | undefined {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,6 +110,8 @@ export type TxHash = string;
 export interface FileManager {
   readBlockNumbers(): BlockNumberData | undefined;
   writeBlockNumbers(data: BlockNumberData): void;
+  getMinDate(): DateString | undefined;
+  getMaxDate(): DateString | undefined;
   readDistributors(): DistributorsData | undefined;
   writeDistributors(data: DistributorsData): void;
   readDistributorBalances(address: Address): BalanceData | undefined;


### PR DESCRIPTION
## Summary
- Added `getMinDate()` and `getMaxDate()` methods to FileManager to query available dates from block numbers store
- Updated RecipientRecievedScanner to accept optional `endDate` parameter, replacing hardcoded "yesterday" calculation
- Updated BalanceFetcher to accept optional `endDate` parameter for date range filtering
- Updated Orchestrator to use block store max date instead of calculating "yesterday" when no endDate is provided
- Ensures all components are bounded by available data in the block store

## Issue
Closes #257

## Test plan
- [x] Added unit tests for FileManager's new `getMinDate()` and `getMaxDate()` methods
- [x] Added tests for RecipientRecievedScanner's `endDate` parameter functionality
- [x] Added tests for BalanceFetcher's `endDate` filtering behavior
- [x] Updated Orchestrator tests to verify block store date usage
- [x] All existing tests pass
- [x] Followed strict TDD process with Red-Green-Refactor cycles for each component