### PR TITLE
feat: add validation to ensure total_wei is never negative

### DIFF
--- a/__tests__/units/core/fee-calculation/fee-calculator.test.ts
+++ b/__tests__/units/core/fee-calculation/fee-calculator.test.ts
@@ -36,6 +36,7 @@ describe("FeeCalculator Unit Tests", () => {
     it("should set start_balance_wei to previous balance and end_balance_wei to current balance", () => {
       // Test data matching the spec example
       const date = "2024-01-15";
+      const distributorAddress = "0x1234567890123456789012345678901234567890";
       const previousBalanceWei = "1500000000000000000000"; // 1500 ETH (start balance)
       const currentBalanceWei = "1480000000000000000000"; // 1480 ETH (end balance)
       const balanceChangeWei = BigInt("-20000000000000000000"); // -20 ETH
@@ -48,6 +49,7 @@ describe("FeeCalculator Unit Tests", () => {
       const calculatorWithPrivates = calculator as unknown as {
         createDailyEntry: (
           date: string,
+          distributorAddress: string,
           previousBalanceWei: string,
           currentBalanceWei: string,
           balanceChangeWei: bigint,
@@ -69,6 +71,7 @@ describe("FeeCalculator Unit Tests", () => {
       // Now the implementation accepts both previousBalanceWei and currentBalanceWei
       const result = createDailyEntry(
         date,
+        distributorAddress,
         previousBalanceWei,
         currentBalanceWei,
         balanceChangeWei,
@@ -84,6 +87,70 @@ describe("FeeCalculator Unit Tests", () => {
       expect(result.distributions_wei).toBe("25000000000000000000");
       expect(result.distributions_count).toBe(5);
       expect(result.total_wei).toBe("5000000000000000000"); // -20 + 25 = 5
+    });
+
+    it("should log warning when total_wei is negative", () => {
+      // Scenario: Large withdrawal causes negative balance change exceeding distributions
+      const date = "2024-01-20";
+      const distributorAddress = "0x1234567890123456789012345678901234567890";
+      const previousBalanceWei = "1000000000000000000000"; // 1000 ETH
+      const currentBalanceWei = "500000000000000000000"; // 500 ETH
+      const balanceChangeWei = BigInt("-500000000000000000000"); // -500 ETH (large withdrawal)
+      const distributionsWei = BigInt("100000000000000000000"); // 100 ETH distributed
+      const distributionsCount = 10;
+
+      // Mock console.warn
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      // Access private method through reflection for unit testing
+      // Note: We're updating the expected signature to include distributorAddress
+      const calculatorWithPrivates = calculator as unknown as {
+        createDailyEntry: (
+          date: string,
+          distributorAddress: string,
+          previousBalanceWei: string,
+          currentBalanceWei: string,
+          balanceChangeWei: bigint,
+          distributionsWei: bigint,
+          distributionsCount: number,
+        ) => {
+          date: string;
+          start_balance_wei: string;
+          end_balance_wei: string;
+          balance_change_wei: string;
+          distributions_wei: string;
+          distributions_count: number;
+          total_wei: string;
+        };
+      };
+      const createDailyEntry =
+        calculatorWithPrivates.createDailyEntry.bind(calculator);
+
+      // Create entry with negative total_wei
+      const result = createDailyEntry(
+        date,
+        distributorAddress,
+        previousBalanceWei,
+        currentBalanceWei,
+        balanceChangeWei,
+        distributionsWei,
+        distributionsCount,
+      );
+
+      // Verify warning was logged with all required information
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Negative total_wei detected for distributor 0x1234567890123456789012345678901234567890 on 2024-01-20: -400000000000000000000 wei (balance_change_wei: -500000000000000000000, distributions_wei: 100000000000000000000)",
+        ),
+      );
+
+      // Verify result still contains negative total_wei
+      expect(result.total_wei).toBe("-400000000000000000000");
+
+      // Restore console.warn
+      consoleWarnSpy.mockRestore();
     });
   });
 

--- a/src/core/fee-calculation/fee-calculator.ts
+++ b/src/core/fee-calculation/fee-calculator.ts
@@ -94,6 +94,7 @@ export class FeeCalculator {
 
     // Process all dates to create daily entries
     return this.createDailyEntries(
+      distributorAddress,
       sortedDates,
       balanceData.balances,
       eventsData,
@@ -101,6 +102,7 @@ export class FeeCalculator {
   }
 
   private createDailyEntries(
+    distributorAddress: string,
     sortedDates: string[],
     balances: { [date: string]: { block_number: number; balance_wei: string } },
     eventsData: RecipientRecievedEventData | undefined,
@@ -127,6 +129,7 @@ export class FeeCalculator {
       dailyEntries.push(
         this.createDailyEntry(
           date,
+          distributorAddress,
           previousBalanceWei,
           currentBalance.balance_wei,
           balanceChangeWei,
@@ -152,6 +155,7 @@ export class FeeCalculator {
 
   private createDailyEntry(
     date: string,
+    distributorAddress: string,
     previousBalanceWei: string,
     currentBalanceWei: string,
     balanceChangeWei: bigint,
@@ -160,6 +164,13 @@ export class FeeCalculator {
   ): FeeReportEntry {
     // Calculate total_wei as sum of balance change and distributions
     const totalWei = balanceChangeWei + distributionsWei;
+
+    // Check if total_wei is negative and log warning
+    if (totalWei < 0n) {
+      console.warn(
+        `Negative total_wei detected for distributor ${distributorAddress} on ${date}: ${totalWei.toString()} wei (balance_change_wei: ${balanceChangeWei.toString()}, distributions_wei: ${distributionsWei.toString()})`,
+      );
+    }
 
     return {
       date,


### PR DESCRIPTION
## Summary
- Add warning log when total_wei is negative in fee calculator
- Log includes distributor address, date, negative amount, balance change, and distributions for context
- Continue processing without throwing errors

## Issue
Closes #259

## Implementation Details
Following TDD approach:
1. **RED Phase**: Added test expecting console.warn for negative total_wei
2. **GREEN Phase**: Implemented minimal warning logic in createDailyEntry method
3. **REFACTOR Phase**: No refactoring needed - implementation is simple and clear

## Changes
- Updated `createDailyEntry` method signature to accept distributor address
- Added check for negative total_wei and appropriate warning log
- Updated method calls throughout to pass distributor address

## Testing
- Added unit test to verify warning is logged with correct information
- Existing integration tests confirm warnings are triggered for real data
- All tests passing

## Test plan
- [x] Run unit tests: `npm test -- __tests__/units/core/fee-calculation/fee-calculator.test.ts`
- [x] Run all tests: `npm test`
- [x] Verify warnings appear in integration test output for real negative total_wei cases
- [x] Confirm fee reports are still generated correctly despite warnings