### PR TITLE
chore: convert RPC calls to sequential processing for rate limit compliance

### DIFF
--- a/src/core/distributor-detection/distributor-detector.ts
+++ b/src/core/distributor-detection/distributor-detector.ts
@@ -200,10 +200,14 @@ export class DistributorDetector {
       allLogs.push(...logs);
     }
 
-    // Process all logs in parallel for better performance
-    const processedResults = await Promise.all(
-      allLogs.map((log) => this.processLogEvent(log, provider)),
-    );
+    // Process logs sequentially to avoid RPC rate limiting issues
+    // Sequential processing ensures we don't overwhelm RPC providers with concurrent requests
+    // which can lead to 429 (rate limit) errors and degraded performance
+    const processedResults: DistributorInfo[] = [];
+    for (const log of allLogs) {
+      const distributorInfo = await this.processLogEvent(log, provider);
+      processedResults.push(distributorInfo);
+    }
 
     // Sort by block number
     return processedResults.sort((a, b) => a.block - b.block);


### PR DESCRIPTION
## Summary
- Convert Promise.all pattern to sequential processing in distributor-detector.ts
- Add documentation explaining the sequential processing approach
- Prevent 429 rate limit errors from RPC providers

## Changes
- Replace Promise.all with sequential for loop in `scanBlockRange` method (src/core/distributor-detection/distributor-detector.ts:204-210)
- Add clear comments explaining why sequential processing is used for RPC calls

## Context
The project needs to ensure all RPC requests are processed sequentially rather than concurrently to avoid rate limiting issues with RPC providers. This change aligns with existing patterns in the codebase (like block-finder.ts).

## Testing
- All existing tests pass without modification
- Behavior remains identical (only execution order changes from parallel to sequential)

Resolves #262