### PR TITLE
fix: correct logging string in processLogEvent function

### DIFF
--- a/src/core/distributor-detection/distributor-detector.ts
+++ b/src/core/distributor-detection/distributor-detector.ts
@@ -149,7 +149,7 @@ export class DistributorDetector {
     // Get block timestamp with retry logic
     const block = await withRetry(() => provider.getBlock(log.blockNumber), {
       maxRetries: 3,
-      operationName: `scanBlockRange.getBlock(${log.blockNumber})`,
+      operationName: `processLogEvent.getBlock(${log.blockNumber})`,
     });
 
     if (!block) {


### PR DESCRIPTION
## Summary
- Fixed incorrect logging string in the `processLogEvent` function that referenced `scanBlockRange.getBlock` instead of `processLogEvent.getBlock`
- This change makes debugging and log analysis more accurate by correctly representing where operations are occurring

## Changes
- Updated `operationName` parameter in `withRetry` call at line 152 in `src/core/distributor-detection/distributor-detector.ts`
- Changed from `scanBlockRange.getBlock(${log.blockNumber})` to `processLogEvent.getBlock(${log.blockNumber})`

## Test plan
No tests were required for this logging string fix as requested by the user.

Closes #273