### PR TITLE
fix: use max block from store in distributor detector instead of endDate

### DIFF
--- a/__tests__/integration/distributor-detector-integration.test.ts
+++ b/__tests__/integration/distributor-detector-integration.test.ts
@@ -34,6 +34,25 @@ function createNovaProvider(): ethers.JsonRpcProvider {
   });
 }
 
+/**
+ * Filters testBlockNumbers to only include dates up to (and including) the given date.
+ * Used to control the scan range since detectDistributors scans to the max block in the store.
+ */
+function blockNumbersUpTo(maxDate: string): BlockNumberData {
+  const filtered: Record<string, number> = {};
+  for (const [date, block] of Object.entries(
+    (testBlockNumbers as BlockNumberData).blocks,
+  )) {
+    if (date <= maxDate) {
+      filtered[date] = block;
+    }
+  }
+  return {
+    metadata: (testBlockNumbers as BlockNumberData).metadata,
+    blocks: filtered,
+  };
+}
+
 describe("DistributorDetector - Integration Tests", () => {
   let testContext: TestContext;
   let distributorDetector: DistributorDetector;
@@ -57,14 +76,11 @@ describe("DistributorDetector - Integration Tests", () => {
 
   describe("Complete Data Lifecycle", () => {
     it("should detect distributors from scratch with real FileManager and test data", async () => {
-      // Step 1: Write block numbers to FileManager
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
+      // Step 1: Write block numbers up to July 13, 2022 (after first 2 distributors)
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-07-13"));
 
-      // Step 2: Run initial detection up to July 13, 2022 (after first 2 distributors)
-      const endDate1 = new Date("2022-07-13");
-      const result1 = await distributorDetector.detectDistributors(endDate1);
+      // Step 2: Run detection
+      const result1 = await distributorDetector.detectDistributors();
 
       // Verify initial detection results
       expect(result1.metadata.chain_id).toBe(42170);
@@ -118,35 +134,26 @@ describe("DistributorDetector - Integration Tests", () => {
     });
 
     it("should perform incremental scanning across multiple calls", async () => {
-      // Setup: Write block numbers
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
-
-      // Step 1: Initial scan up to July 12, 2022 (finds first distributor at block 152)
-      const endDate1 = new Date("2022-07-12");
-      const result1 = await distributorDetector.detectDistributors(endDate1);
+      // Step 1: Write blocks up to July 12, 2022 and scan (finds first distributor at block 152)
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-07-12"));
+      const result1 = await distributorDetector.detectDistributors();
 
       expect(result1.metadata.last_scanned_block).toBe(155);
       expect(Object.keys(result1.distributors).length).toBe(1);
 
-      // Step 2: Incremental scan up to Aug 9, 2022 (finds L2_BASE_FEE at block 684)
-      const endDate2 = new Date("2022-08-09");
-      const result2 = await distributorDetector.detectDistributors(endDate2);
+      // Step 2: Extend blocks to Aug 9, 2022 and scan (finds L2_BASE_FEE at block 684)
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-08-09"));
+      const result2 = await distributorDetector.detectDistributors();
 
       expect(result2.metadata.last_scanned_block).toBe(3584);
       expect(Object.keys(result2.distributors).length).toBe(2);
 
-      // Step 3: For efficiency, we'll test one more incremental scan with a smaller range
-      // Add a custom date that's far enough to test chunking but not too far
-      const customBlockNumbers = JSON.parse(JSON.stringify(testBlockNumbers));
-      customBlockNumbers.blocks["2022-09-15"] = 53584; // 50,000 blocks past previous scan
-      testContext.fileManager.writeBlockNumbers(
-        customBlockNumbers as BlockNumberData,
-      );
+      // Step 3: Extend with a custom date far enough to test chunking but not too far
+      const extendedBlocks = blockNumbersUpTo("2022-08-09");
+      extendedBlocks.blocks["2022-09-15"] = 53584; // 50,000 blocks past previous scan
+      testContext.fileManager.writeBlockNumbers(extendedBlocks);
 
-      const endDate3 = new Date("2022-09-15");
-      const result3 = await distributorDetector.detectDistributors(endDate3);
+      const result3 = await distributorDetector.detectDistributors();
 
       // Verify incremental scanning worked
       expect(result3.metadata.last_scanned_block).toBe(53584);
@@ -163,14 +170,11 @@ describe("DistributorDetector - Integration Tests", () => {
     });
 
     it("should recover state correctly after process restart", async () => {
-      // Setup: Write block numbers
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
+      // Setup: Write block numbers up to Aug 9, 2022
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-08-09"));
 
       // Step 1: Initial detection
-      const endDate = new Date("2022-08-09");
-      const result1 = await distributorDetector.detectDistributors(endDate);
+      const result1 = await distributorDetector.detectDistributors();
       expect(Object.keys(result1.distributors).length).toBe(2);
 
       // Step 2: Simulate process restart with new instances
@@ -180,19 +184,18 @@ describe("DistributorDetector - Integration Tests", () => {
       const newDetector = new DistributorDetector(newFileManager, newProvider);
 
       try {
-        // Step 3: Run detection again with same date (should not re-scan)
-        const result2 = await newDetector.detectDistributors(endDate);
+        // Step 3: Run detection again with same block data (should not re-scan)
+        const result2 = await newDetector.detectDistributors();
 
         // Should return same data without additional scanning
         expect(result2).toEqual(result1);
 
-        // Step 4: Extend detection to new date - use a custom date for efficiency
-        const customBlockNumbers = JSON.parse(JSON.stringify(testBlockNumbers));
-        customBlockNumbers.blocks["2022-10-01"] = 100000; // Scan ~96k blocks from 3584
-        newFileManager.writeBlockNumbers(customBlockNumbers as BlockNumberData);
+        // Step 4: Extend block data to test incremental scan
+        const extendedBlocks = blockNumbersUpTo("2022-08-09");
+        extendedBlocks.blocks["2022-10-01"] = 100000; // Scan ~96k blocks from 3584
+        newFileManager.writeBlockNumbers(extendedBlocks);
 
-        const newEndDate = new Date("2022-10-01");
-        const result3 = await newDetector.detectDistributors(newEndDate);
+        const result3 = await newDetector.detectDistributors();
 
         // Verify incremental scan worked
         expect(result3.metadata.last_scanned_block).toBe(100000);
@@ -231,13 +234,10 @@ describe("DistributorDetector - Integration Tests", () => {
       };
 
       testContext.fileManager.writeDistributors(existingData);
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-08-09"));
 
       // Run detection that will encounter the same distributor
-      const endDate = new Date("2022-08-09");
-      const result = await distributorDetector.detectDistributors(endDate);
+      const result = await distributorDetector.detectDistributors();
 
       // Verify distributor was not overwritten
       expect(
@@ -266,15 +266,13 @@ describe("DistributorDetector - Integration Tests", () => {
       };
 
       testContext.fileManager.writeDistributors(existingData);
-      const customBlockNumbers = JSON.parse(JSON.stringify(testBlockNumbers));
-      customBlockNumbers.blocks["2023-02-15"] = 3165000; // Just past the events
-      testContext.fileManager.writeBlockNumbers(
-        customBlockNumbers as BlockNumberData,
-      );
+      testContext.fileManager.writeBlockNumbers({
+        metadata: { chain_id: 42170 },
+        blocks: { "2023-02-15": 3165000 },
+      });
 
       // Run detection for a smaller range
-      const endDate = new Date("2023-02-15");
-      const result = await distributorDetector.detectDistributors(endDate);
+      const result = await distributorDetector.detectDistributors();
 
       // Check specific distributor known to be a reward distributor
       expect(
@@ -290,52 +288,40 @@ describe("DistributorDetector - Integration Tests", () => {
   describe("Error Scenarios", () => {
     it("should throw error when block numbers file is missing", async () => {
       // Don't write block numbers file
-      const endDate = new Date("2023-03-16");
-
-      await expect(
-        distributorDetector.detectDistributors(endDate),
-      ).rejects.toThrow("Block numbers data not found");
+      await expect(distributorDetector.detectDistributors()).rejects.toThrow(
+        "Block numbers data not found",
+      );
     });
 
-    it("should throw error when end date not found in block numbers", async () => {
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
+    it("should throw error when block numbers data is empty", async () => {
+      testContext.fileManager.writeBlockNumbers({
+        metadata: { chain_id: 42170 },
+        blocks: {},
+      });
+
+      await expect(distributorDetector.detectDistributors()).rejects.toThrow(
+        "Block numbers data is empty",
       );
-
-      // Use date not in block numbers (test data ends at 2025-06-23)
-      const endDate = new Date("2026-01-01");
-
-      await expect(
-        distributorDetector.detectDistributors(endDate),
-      ).rejects.toThrow("Block number not found for date 2026-01-01");
     });
   });
 
   describe("Data Persistence Verification", () => {
     it("should maintain chain_id consistency across updates", async () => {
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
-
-      // First run
-      const endDate1 = new Date("2022-07-12");
-      const result1 = await distributorDetector.detectDistributors(endDate1);
+      // First run with blocks up to July 12
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-07-12"));
+      const result1 = await distributorDetector.detectDistributors();
       expect(result1.metadata.chain_id).toBe(42170);
 
-      // Second run with a small incremental scan
-      const endDate2 = new Date("2022-08-09");
-      const result2 = await distributorDetector.detectDistributors(endDate2);
+      // Second run with blocks extended to Aug 9
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-08-09"));
+      const result2 = await distributorDetector.detectDistributors();
       expect(result2.metadata.chain_id).toBe(42170);
     });
 
     it("should create proper directory structure for distributors", async () => {
-      testContext.fileManager.writeBlockNumbers(
-        testBlockNumbers as BlockNumberData,
-      );
-
-      // Use a small date range that still finds distributors
-      const endDate = new Date("2022-07-12");
-      await distributorDetector.detectDistributors(endDate);
+      // Write blocks up to a small date that still finds distributors
+      testContext.fileManager.writeBlockNumbers(blockNumbersUpTo("2022-07-12"));
+      await distributorDetector.detectDistributors();
 
       // Verify file structure
       const storePath = path.join(testContext.tempDir, "store");

--- a/__tests__/units/core/distributor-detection/detect-distributors.test.ts
+++ b/__tests__/units/core/distributor-detection/detect-distributors.test.ts
@@ -89,24 +89,23 @@ describe("DistributorDetector.detectDistributors", () => {
   describe("successful detection", () => {
     it("should handle first run when no existing data exists", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       mockFileManager.readDistributors.mockReturnValue(undefined);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
       scanBlockRangeSpy.mockResolvedValue([newDistributorInfo]);
 
       // Act
-      const result = await detector.detectDistributors(endDate);
+      const result = await detector.detectDistributors();
 
       // Assert
       expect(mockFileManager.readDistributors).toHaveBeenCalledTimes(1);
       expect(mockFileManager.readBlockNumbers).toHaveBeenCalledTimes(1);
-      expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 0, 300);
+      expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 0, 400);
 
       const expectedData: DistributorsData = {
         metadata: {
           chain_id: 42170,
           arbowner_address: "0x0000000000000000000000000000000000000070",
-          last_scanned_block: 300,
+          last_scanned_block: 400,
         },
         distributors: {
           "0xABCDEF0123456789ABCDEF0123456789ABCDEF01": [newDistributorInfo],
@@ -121,13 +120,12 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should perform incremental scan from last_scanned_block", async () => {
       // Arrange
-      const endDate = new Date("2023-03-17");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
       scanBlockRangeSpy.mockResolvedValue([newDistributorInfo]);
 
       // Act
-      const result = await detector.detectDistributors(endDate);
+      const result = await detector.detectDistributors();
 
       // Assert
       expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 151, 400);
@@ -155,19 +153,18 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should return existing data without scanning when already up-to-date", async () => {
       // Arrange
-      const endDate = new Date("2023-03-15");
       const upToDateDistributors = {
         ...existingDistributors,
         metadata: {
           ...existingDistributors.metadata,
-          last_scanned_block: 200,
+          last_scanned_block: 400,
         },
       };
       mockFileManager.readDistributors.mockReturnValue(upToDateDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
 
       // Act
-      const result = await detector.detectDistributors(endDate);
+      const result = await detector.detectDistributors();
 
       // Assert
       expect(scanBlockRangeSpy).not.toHaveBeenCalled();
@@ -177,21 +174,20 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should handle empty scan results", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
       scanBlockRangeSpy.mockResolvedValue([]);
 
       // Act
-      const result = await detector.detectDistributors(endDate);
+      const result = await detector.detectDistributors();
 
       // Assert
-      expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 151, 300);
+      expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 151, 400);
 
       const expectedData: DistributorsData = {
         metadata: {
           ...existingDistributors.metadata,
-          last_scanned_block: 300,
+          last_scanned_block: 400,
         },
         distributors: existingDistributors.distributors,
       };
@@ -204,7 +200,6 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should skip already known distributors", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       const existingDistributorInfo =
         existingDistributors.distributors[
           "0x1234567890123456789012345678901234567890"
@@ -229,13 +224,13 @@ describe("DistributorDetector.detectDistributors", () => {
       ]);
 
       // Act
-      const result = await detector.detectDistributors(endDate);
+      const result = await detector.detectDistributors();
 
       // Assert
       const expectedData: DistributorsData = {
         metadata: {
           ...existingDistributors.metadata,
-          last_scanned_block: 300,
+          last_scanned_block: 400,
         },
         distributors: {
           "0x1234567890123456789012345678901234567890":
@@ -254,15 +249,17 @@ describe("DistributorDetector.detectDistributors", () => {
   });
 
   describe("error handling", () => {
-    it("should throw error when end date not found in block numbers", async () => {
+    it("should throw error when block numbers data is empty", async () => {
       // Arrange
-      const endDate = new Date("2023-03-20");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
-      mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
+      mockFileManager.readBlockNumbers.mockReturnValue({
+        metadata: { chain_id: 42170 },
+        blocks: {},
+      });
 
       // Act & Assert
-      await expect(detector.detectDistributors(endDate)).rejects.toThrow(
-        "Block number not found for date 2023-03-20",
+      await expect(detector.detectDistributors()).rejects.toThrow(
+        "Block numbers data is empty",
       );
 
       expect(scanBlockRangeSpy).not.toHaveBeenCalled();
@@ -271,12 +268,11 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should throw error when block numbers data is missing", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(undefined);
 
       // Act & Assert
-      await expect(detector.detectDistributors(endDate)).rejects.toThrow(
+      await expect(detector.detectDistributors()).rejects.toThrow(
         "Block numbers data not found",
       );
 
@@ -286,14 +282,13 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should propagate errors from scanBlockRange", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       const scanError = new Error("RPC connection failed");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
       scanBlockRangeSpy.mockRejectedValue(scanError);
 
       // Act & Assert
-      await expect(detector.detectDistributors(endDate)).rejects.toThrow(
+      await expect(detector.detectDistributors()).rejects.toThrow(
         "RPC connection failed",
       );
 
@@ -302,7 +297,6 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should propagate errors from FileManager writes", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       const writeError = new Error("Disk full");
       mockFileManager.readDistributors.mockReturnValue(existingDistributors);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
@@ -312,22 +306,19 @@ describe("DistributorDetector.detectDistributors", () => {
       scanBlockRangeSpy.mockResolvedValue([newDistributorInfo]);
 
       // Act & Assert
-      await expect(detector.detectDistributors(endDate)).rejects.toThrow(
-        "Disk full",
-      );
+      await expect(detector.detectDistributors()).rejects.toThrow("Disk full");
     });
   });
 
   describe("chain ID handling", () => {
     it("should get chain ID from provider for new data", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       mockFileManager.readDistributors.mockReturnValue(undefined);
       mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
       scanBlockRangeSpy.mockResolvedValue([newDistributorInfo]);
 
       // Act
-      await detector.detectDistributors(endDate);
+      await detector.detectDistributors();
 
       // Assert
       expect(mockProvider.getNetwork).toHaveBeenCalledTimes(1);
@@ -338,7 +329,6 @@ describe("DistributorDetector.detectDistributors", () => {
 
     it("should preserve existing chain ID when updating", async () => {
       // Arrange
-      const endDate = new Date("2023-03-16");
       const existingWithDifferentChain = {
         ...existingDistributors,
         metadata: {
@@ -353,30 +343,13 @@ describe("DistributorDetector.detectDistributors", () => {
       scanBlockRangeSpy.mockResolvedValue([newDistributorInfo]);
 
       // Act
-      await detector.detectDistributors(endDate);
+      await detector.detectDistributors();
 
       // Assert
       expect(mockProvider.getNetwork).not.toHaveBeenCalled();
       const writtenData = mockFileManager.writeDistributors.mock
         .calls[0]![0] as DistributorsData;
       expect(writtenData.metadata.chain_id).toBe(99999);
-    });
-  });
-
-  describe("date formatting", () => {
-    it("should format date correctly for block lookup", async () => {
-      // Arrange
-      const endDate = new Date("2023-03-16T12:34:56.789Z");
-      mockFileManager.readDistributors.mockReturnValue(existingDistributors);
-      mockFileManager.readBlockNumbers.mockReturnValue(testBlockNumbers);
-      scanBlockRangeSpy.mockResolvedValue([]);
-
-      // Act
-      await detector.detectDistributors(endDate);
-
-      // Assert
-      expect(mockFileManager.readBlockNumbers).toHaveBeenCalled();
-      expect(scanBlockRangeSpy).toHaveBeenCalledWith(mockProvider, 151, 300);
     });
   });
 });

--- a/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
+++ b/__tests__/units/infrastructure/orchestration/orchestrator.test.ts
@@ -541,12 +541,10 @@ describe("orchestrator", () => {
       global.Date = originalDate;
     });
 
-    it("should pass endDate to distributorDetector", async () => {
+    it("should call distributorDetector without parameters", async () => {
       await orchestrate(configuration);
 
-      expect(mockDistributorDetector.detectDistributors).toHaveBeenCalledWith(
-        new Date(configuration.endDate!),
-      );
+      expect(mockDistributorDetector.detectDistributors).toHaveBeenCalledWith();
     });
 
     it("should call balanceFetcher without parameters", async () => {

--- a/docs/specs/distributor-detector.md
+++ b/docs/specs/distributor-detector.md
@@ -112,11 +112,10 @@ class DistributorDetector {
  * Scans OwnerActs events from the last scanned block to find new distributors.
  * Tracks its own progress to support incremental scanning.
  *
- * @param endDate - Scan up to this date
  * @returns Updated distributor registry data
  * @throws Error if unable to query events or write data
  */
-async detectDistributors(endDate: Date): Promise<DistributorsData>;
+async detectDistributors(): Promise<DistributorsData>;
 ```
 
 ### Public Static Methods
@@ -406,10 +405,8 @@ const fileManager = new FileManager("./store");
 // Create DistributorDetector instance
 const distributorDetector = new DistributorDetector(fileManager, provider);
 
-// Detect distributors up to end of January 2024
-const distributors = await distributorDetector.detectDistributors(
-  new Date("2024-01-31"),
-);
+// Detect distributors up to the latest block in the store
+const distributors = await distributorDetector.detectDistributors();
 
 console.log(
   `Found ${Object.keys(distributors.distributors).length} distributors`,

--- a/src/core/distributor-detection/distributor-detector.ts
+++ b/src/core/distributor-detection/distributor-detector.ts
@@ -218,17 +218,16 @@ export class DistributorDetector {
   }
 
   /**
-   * Detects new distributors up to a specified end date by scanning blockchain events.
+   * Detects new distributors by scanning blockchain events up to the latest block in the store.
    * Performs incremental scanning from the last processed block.
    *
-   * @param endDate - The date to scan up to (inclusive)
    * @returns Complete DistributorsData object with all known distributors
-   * @throws Error if end date not found in block numbers data
+   * @throws Error if block numbers data not found or empty
    */
-  async detectDistributors(endDate: Date): Promise<DistributorsData> {
+  async detectDistributors(): Promise<DistributorsData> {
     // Load existing data and determine scan range
     const existingData = this.fileManager.readDistributors();
-    const endBlock = this.getBlockForDate(endDate);
+    const endBlock = this.getMaxBlock();
     const scanRange = this.calculateScanRange(existingData, endBlock);
     if (scanRange.fromBlock === scanRange.toBlock) {
       // nothing to scan - this can happen when there are no blocks on a given day
@@ -261,23 +260,21 @@ export class DistributorDetector {
   }
 
   /**
-   * Gets the block number for a given date from block numbers data.
+   * Gets the maximum block number from the block numbers store.
    * @private
    */
-  private getBlockForDate(date: Date): number {
+  private getMaxBlock(): number {
     const blockNumbersData = this.fileManager.readBlockNumbers();
     if (!blockNumbersData) {
       throw new Error("Block numbers data not found");
     }
 
-    const dateString = date.toISOString().split("T")[0]!;
-    const blockNumber = blockNumbersData.blocks[dateString];
-
-    if (blockNumber === undefined) {
-      throw new Error(`Block number not found for date ${dateString}`);
+    const blockNumbers = Object.values(blockNumbersData.blocks);
+    if (blockNumbers.length === 0) {
+      throw new Error("Block numbers data is empty");
     }
 
-    return blockNumber;
+    return Math.max(...blockNumbers);
   }
 
   /**

--- a/src/infrastructure/orchestration/orchestrator.ts
+++ b/src/infrastructure/orchestration/orchestrator.ts
@@ -123,7 +123,7 @@ async function executePipeline(
   // 2. Detect distributors up to end date
   logger.log("Starting Distributor Detector...");
   const distributorDetector = new DistributorDetector(fileManager, provider);
-  await distributorDetector.detectDistributors(endDate);
+  await distributorDetector.detectDistributors();
 
   // 3. Fetch distributor balances
   logger.log("Starting Balance Fetcher...");


### PR DESCRIPTION
The distributor detector would crash when the block finder skipped dates (e.g. chain behind), since it required the exact endDate to exist in the block numbers store. Now it uses the max block available in the store, making it resilient to missing dates.